### PR TITLE
remove plain-string interpolation for now

### DIFF
--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\BooleanType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\BinaryOp\Concat;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
@@ -96,7 +97,7 @@ final class QueryReflection
         }
 
         $type = $scope->getType($expr);
-        if ($type instanceof ConstantStringType) {
+        if ($type instanceof ConstantScalarType) {
             return $type->getValue();
         }
 
@@ -108,11 +109,6 @@ final class QueryReflection
         $booleanType = new BooleanType();
         if ($booleanType->isSuperTypeOf($type)->yes()) {
             return '1';
-        }
-
-        $stringType = new StringType();
-        if ($stringType->isSuperTypeOf($type)->yes()) {
-            return '1=1';
         }
 
         $floatType = new FloatType();

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -98,7 +98,7 @@ final class QueryReflection
 
         $type = $scope->getType($expr);
         if ($type instanceof ConstantScalarType) {
-            return $type->getValue();
+            return (string) $type->getValue();
         }
 
         $integerType = new IntegerType();

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -116,7 +116,7 @@ final class QueryReflection
             return '1.0';
         }
 
-        if ($type instanceof MixedType) {
+        if ($type instanceof MixedType || $type instanceof StringType) {
             return null;
         }
 

--- a/tests/data/pdo.php
+++ b/tests/data/pdo.php
@@ -49,16 +49,18 @@ class Foo
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid='.$int, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $stmt);
 
-        $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$string, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $stmt);
-
         $stmt = $pdo->query('SELECT akid FROM ak WHERE eadavk>'.$float, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{akid: int<-2147483648, 2147483647>}>', $stmt); // akid is not an auto-increment
 
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid='.$bool, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $stmt);
 
-        $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$mixed, PDO::FETCH_ASSOC);
+		// ---- too queries, for which we cannot infer the return type
+
+		$stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$string, PDO::FETCH_ASSOC);
+		assertType('PDOStatement<array>|false', $stmt);
+
+		$stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$mixed, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array>|false', $stmt);
     }
 

--- a/tests/data/pdo.php
+++ b/tests/data/pdo.php
@@ -55,12 +55,12 @@ class Foo
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid='.$bool, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $stmt);
 
-		// ---- too queries, for which we cannot infer the return type
+        // ---- too queries, for which we cannot infer the return type
 
-		$stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$string, PDO::FETCH_ASSOC);
-		assertType('PDOStatement<array>|false', $stmt);
+        $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$string, PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array>|false', $stmt);
 
-		$stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$mixed, PDO::FETCH_ASSOC);
+        $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$mixed, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array>|false', $stmt);
     }
 


### PR DESCRIPTION
replacing a plain string with a candidate is pretty hard, as we atm don't know where wihtin the query the string is used.

we would need more information about the query structure to find a proper replace candidate.