### PR TITLE
cover quoted query strings with tests

### DIFF
--- a/.phpstan-dba.cache
+++ b/.phpstan-dba.cache
@@ -429,6 +429,75 @@
         )),
       ),
     ),
+    'SELECT email, adaid FROM ada WHERE adaid=1' => 
+    array (
+      'error' => NULL,
+      'result' => 
+      array (
+        1 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+              )),
+            ),
+          )),
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => 0,
+                 'max' => 4294967295,
+              )),
+              1 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+          ),
+           'nextAutoIndex' => 0,
+           'optionalKeys' => 
+          array (
+          ),
+           'allArrays' => NULL,
+        )),
+      ),
+    ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada' => 
     array (
       'error' => NULL,

--- a/tests/data/mysqli.php
+++ b/tests/data/mysqli.php
@@ -78,23 +78,23 @@ class Foo
      */
     public function quotedArguments(mysqli $mysqli, int $i, float $f, $n, string $s, $nonE, string $numericString)
     {
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $i));
-		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $i));
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
 
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $f));
-		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $f));
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
 
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $n));
-		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $n));
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
 
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($numericString));
-		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($numericString));
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
 
         // when quote() cannot return a numeric-string, we can't infer the precise result-type
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($s));
-		assertType('bool|mysqli_result', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($s));
+        assertType('bool|mysqli_result', $result);
 
-		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($nonE));
-		assertType('bool|mysqli_result', $result);
+        $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($nonE));
+        assertType('bool|mysqli_result', $result);
     }
 }

--- a/tests/data/mysqli.php
+++ b/tests/data/mysqli.php
@@ -70,4 +70,31 @@ class Foo
         assertType('non-empty-string', $mysqli->real_escape_string($nonE));
         assertType('string', $mysqli->real_escape_string($s));
     }
+
+    /**
+     * @param numeric          $n
+     * @param non-empty-string $nonE
+     * @param numeric-string   $numericString
+     */
+    public function quotedArguments(mysqli $mysqli, int $i, float $f, $n, string $s, $nonE, string $numericString)
+    {
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $i));
+		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $f));
+		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $n));
+		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($numericString));
+		assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+
+        // when quote() cannot return a numeric-string, we can't infer the precise result-type
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($s));
+		assertType('bool|mysqli_result', $result);
+
+		$result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($nonE));
+		assertType('bool|mysqli_result', $result);
+    }
 }

--- a/tests/data/pdo.php
+++ b/tests/data/pdo.php
@@ -172,4 +172,31 @@ class Foo
         assertType('non-empty-string|false', $pdo->quote($nonE, PDO::PARAM_LOB));
         assertType('string|false', $pdo->quote($s, PDO::PARAM_LOB));
     }
+
+    /**
+     * @param numeric          $n
+     * @param non-empty-string $nonE
+     * @param numeric-string   $numericString
+     */
+    public function quotedArguments(PDO $pdo, int $i, float $f, $n, string $s, $nonE, string $numericString)
+    {
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote((string) $i), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>}>', $stmt);
+
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote((string) $f), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>}>', $stmt);
+
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote((string) $n), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>}>', $stmt);
+
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote($numericString), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<0, 4294967295>}>', $stmt);
+
+        // when quote() cannot return a numeric-string, we can't infer the precise result-type
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote($s), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array>|false', $stmt);
+
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote($nonE), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array>|false', $stmt);
+    }
 }


### PR DESCRIPTION
these cases are supported with the newly added mysqli->real_escape_string() and pdo->quote() return type extensions