### PR TITLE
remove `false` from return types, when error mode is exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ composer require --dev staabm/phpstan-dba
 
 - running `RecordingQueryReflector` requires in PHPStan-non-debug mode (currently we see concurrency issues while building the cache).
 - when analyzing a php8+ codebase, [`PDO::ERRMODE_EXCEPTION` error handling](https://www.php.net/manual/en/pdo.error-handling.php) is assumed.
+- when analyzing a php8.1+ codebase, [`mysqli_report(\MYSQLI_REPORT_ERROR | \MYSQLI_REPORT_STRICT);` error handling](https://www.php.net/mysqli_report) is assumed.
 
 ## Todos
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ services:
 
 __the callable format is `funtionName#parameterIndex`, while the parameter-index defines the position of the query-string argument.__
 
+## Runtime configuration
+
+Within your phpstan-bootstrap file you can configure phpstan-dba so it knows about global runtime configuration state, which cannot be detect automatically.
+Use the [`RuntimeConfiguration`](https://github.com/staabm/phpstan-dba/tree/main/src/QueryReflection/RuntimeConfiguration.php) builder-object and pass it as a second argument to `QueryReflection::setupReflector()`.
+
+If not configured otherwise, the following defaults are used:
+- when analyzing a php8+ codebase, [`PDO::ERRMODE_EXCEPTION` error handling](https://www.php.net/manual/en/pdo.error-handling.php) is assumed.
+- when analyzing a php8.1+ codebase, [`mysqli_report(\MYSQLI_REPORT_ERROR | \MYSQLI_REPORT_STRICT);` error handling](https://www.php.net/mysqli_report) is assumed.
+
 ## Installation
 
 ```shell
@@ -125,8 +134,6 @@ composer require --dev staabm/phpstan-dba
 ## Caveats
 
 - running `RecordingQueryReflector` requires in PHPStan-non-debug mode (currently we see concurrency issues while building the cache).
-- when analyzing a php8+ codebase, [`PDO::ERRMODE_EXCEPTION` error handling](https://www.php.net/manual/en/pdo.error-handling.php) is assumed.
-- when analyzing a php8.1+ codebase, [`mysqli_report(\MYSQLI_REPORT_ERROR | \MYSQLI_REPORT_STRICT);` error handling](https://www.php.net/mysqli_report) is assumed.
 
 ## Todos
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ composer require --dev staabm/phpstan-dba
 ## Caveats
 
 - running `RecordingQueryReflector` requires in PHPStan-non-debug mode (currently we see concurrency issues while building the cache).
+- when analyzing a php8+ codebase, [`PDO::ERRMODE_EXCEPTION` error handling](https://www.php.net/manual/en/pdo.error-handling.php) is assumed.
 
 ## Todos
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use staabm\PHPStanDba\QueryReflection\RuntimeConfiguration;
 use staabm\PHPStanDba\QueryReflection\MysqliQueryReflector;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\RecordingQueryReflector;
@@ -44,5 +45,6 @@ try {
 }
 
 QueryReflection::setupReflector(
-	$reflector
+	$reflector,
+	RuntimeConfiguration::create()->errorMode(RuntimeConfiguration::ERROR_MODE_EXCEPTION)
 );

--- a/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
@@ -21,6 +21,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
 
 final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension, DynamicFunctionReturnTypeExtension
 {
@@ -54,8 +55,7 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $functionCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80100) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
@@ -73,8 +73,7 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80100) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 

--- a/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
@@ -54,10 +54,10 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $functionCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80100) {
-			$defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80100) {
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
         if (\count($args) < 2) {
             return $defaultReturn;
@@ -73,10 +73,10 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80100) {
-			$defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80100) {
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
         if (0 === \count($args)) {
             return $defaultReturn;

--- a/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntersectionType;
@@ -53,10 +54,10 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $functionCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-        }
+		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+		if ($this->phpVersion->getVersionId() >= 80100) {
+			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+		}
 
         if (\count($args) < 2) {
             return $defaultReturn;
@@ -72,10 +73,10 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-        }
+		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+		if ($this->phpVersion->getVersionId() >= 80100) {
+			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+		}
 
         if (0 === \count($args)) {
             return $defaultReturn;

--- a/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use mysqli;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
@@ -18,18 +19,19 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension, DynamicFunctionReturnTypeExtension
 {
-	/**
-	 * @var PhpVersion
-	 */
-	private $phpVersion;
+    /**
+     * @var PhpVersion
+     */
+    private $phpVersion;
 
-	public function __construct(PhpVersion $phpVersion)
-	{
-		$this->phpVersion = $phpVersion;
-	}
+    public function __construct(PhpVersion $phpVersion)
+    {
+        $this->phpVersion = $phpVersion;
+    }
 
     public function getClass(): string
     {
@@ -49,14 +51,14 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
         $args = $functionCall->getArgs();
-		$defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+        $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80000) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80000) {
+            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
-		if (\count($args) < 2) {
+        if (\count($args) < 2) {
             return $defaultReturn;
         }
 
@@ -68,12 +70,12 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
     {
         $args = $methodCall->getArgs();
-		$defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80000) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80000) {
+            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
         if (0 === \count($args)) {
             return $defaultReturn;

--- a/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliEscapeStringDynamicReturnTypeExtension.php
@@ -56,7 +56,7 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
 
 		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
 		if ($this->phpVersion->getVersionId() >= 80100) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+			$defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
 		}
 
         if (\count($args) < 2) {
@@ -75,7 +75,7 @@ final class MysqliEscapeStringDynamicReturnTypeExtension implements DynamicMetho
 
 		// since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
 		if ($this->phpVersion->getVersionId() >= 80100) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+			$defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
 		}
 
         if (0 === \count($args)) {

--- a/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
@@ -54,8 +54,8 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
         $args = $functionCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80100) {
             TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 

--- a/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
@@ -54,8 +54,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
         $args = $functionCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-        // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80100) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
@@ -71,8 +70,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         $resultType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_ASSOC);
         if ($resultType) {
-            // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-            if ($this->phpVersion->getVersionId() >= 80100) {
+            if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
                 return new GenericObjectType(mysqli_result::class, [$resultType]);
             }
 
@@ -90,8 +88,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
@@ -107,8 +104,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         $resultType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_ASSOC);
         if ($resultType) {
-            // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
-            if ($this->phpVersion->getVersionId() >= 80100) {
+            if (QueryReflection::getRuntimeConfiguration()->throwsMysqliExceptions($this->phpVersion)) {
                 return new GenericObjectType(mysqli_result::class, [$resultType]);
             }
 

--- a/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
@@ -56,7 +56,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80100) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         if (\count($args) < 2) {
@@ -87,7 +87,7 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         // since php8 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         if (\count($args) < 1) {

--- a/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
@@ -23,6 +23,16 @@ use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension, DynamicFunctionReturnTypeExtension
 {
+	/**
+	 * @var PhpVersion
+	 */
+	private $phpVersion;
+
+	public function __construct(PhpVersion $phpVersion)
+	{
+		$this->phpVersion = $phpVersion;
+	}
+
     public function getClass(): string
     {
         return mysqli::class;

--- a/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/MysqliQueryDynamicReturnTypeExtension.php
@@ -71,6 +71,11 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         $resultType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_ASSOC);
         if ($resultType) {
+            // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+            if ($this->phpVersion->getVersionId() >= 80100) {
+                return new GenericObjectType(mysqli_result::class, [$resultType]);
+            }
+
             return TypeCombinator::union(
                 new GenericObjectType(mysqli_result::class, [$resultType]),
                 new ConstantBooleanType(false),
@@ -102,6 +107,11 @@ final class MysqliQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 
         $resultType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_ASSOC);
         if ($resultType) {
+            // since php8.1 the default error mode changed to exception, therefore false returns are not longer possible
+            if ($this->phpVersion->getVersionId() >= 80100) {
+                return new GenericObjectType(mysqli_result::class, [$resultType]);
+            }
+
             return TypeCombinator::union(
                 new GenericObjectType(mysqli_result::class, [$resultType]),
                 new ConstantBooleanType(false),

--- a/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PDO;
 use PDOStatement;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -16,23 +17,22 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Php\PhpVersion;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-	/**
-	 * @var PhpVersion
-	 */
-	private $phpVersion;
+    /**
+     * @var PhpVersion
+     */
+    private $phpVersion;
 
-	public function __construct(PhpVersion $phpVersion)
-	{
-		$this->phpVersion = $phpVersion;
-	}
+    public function __construct(PhpVersion $phpVersion)
+    {
+        $this->phpVersion = $phpVersion;
+    }
 
-	public function getClass(): string
+    public function getClass(): string
     {
         return PDO::class;
     }
@@ -52,10 +52,10 @@ final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnT
             new ConstantBooleanType(false)
         );
 
-		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80000 ) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80000) {
+            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
         if (\count($args) < 1) {
             return $defaultReturn;

--- a/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
@@ -52,8 +52,7 @@ final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnT
             new ConstantBooleanType(false)
         );
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 

--- a/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
@@ -16,12 +16,23 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Php\PhpVersion;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    public function getClass(): string
+	/**
+	 * @var PhpVersion
+	 */
+	private $phpVersion;
+
+	public function __construct(PhpVersion $phpVersion)
+	{
+		$this->phpVersion = $phpVersion;
+	}
+
+	public function getClass(): string
     {
         return PDO::class;
     }
@@ -40,6 +51,11 @@ final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnT
             new GenericObjectType(PDOStatement::class, [new ArrayType($mixed, $mixed)]),
             new ConstantBooleanType(false)
         );
+
+		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
+		if ($this->phpVersion->getVersionId() >= 80000 ) {
+			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+		}
 
         if (\count($args) < 1) {
             return $defaultReturn;

--- a/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoPrepareDynamicReturnTypeExtension.php
@@ -54,7 +54,7 @@ final class PdoPrepareDynamicReturnTypeExtension implements DynamicMethodReturnT
 
         // since php8 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         if (\count($args) < 1) {

--- a/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PDO;
 use PDOStatement;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -17,23 +18,22 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Php\PhpVersion;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-	/**
-	 * @var PhpVersion
-	 */
-	private $phpVersion;
+    /**
+     * @var PhpVersion
+     */
+    private $phpVersion;
 
-	public function __construct(PhpVersion $phpVersion)
-	{
-		$this->phpVersion = $phpVersion;
-	}
+    public function __construct(PhpVersion $phpVersion)
+    {
+        $this->phpVersion = $phpVersion;
+    }
 
-	public function getClass(): string
+    public function getClass(): string
     {
         return PDO::class;
     }
@@ -53,12 +53,12 @@ final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTyp
             new ConstantBooleanType(false)
         );
 
-		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
-		if ($this->phpVersion->getVersionId() >= 80000 ) {
-			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
-		}
+        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80000) {
+            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+        }
 
-		if (\count($args) < 1) {
+        if (\count($args) < 1) {
             return $defaultReturn;
         }
 

--- a/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
@@ -55,7 +55,7 @@ final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 
         // since php8 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         if (\count($args) < 1) {

--- a/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
@@ -17,12 +17,23 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Php\PhpVersion;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    public function getClass(): string
+	/**
+	 * @var PhpVersion
+	 */
+	private $phpVersion;
+
+	public function __construct(PhpVersion $phpVersion)
+	{
+		$this->phpVersion = $phpVersion;
+	}
+
+	public function getClass(): string
     {
         return PDO::class;
     }
@@ -42,7 +53,12 @@ final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTyp
             new ConstantBooleanType(false)
         );
 
-        if (\count($args) < 1) {
+		// since php8 the default error mode changed to exception, therefore false returns are not longer possible
+		if ($this->phpVersion->getVersionId() >= 80000 ) {
+			TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+		}
+
+		if (\count($args) < 1) {
             return $defaultReturn;
         }
 

--- a/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
@@ -53,8 +53,7 @@ final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTyp
             new ConstantBooleanType(false)
         );
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 

--- a/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
@@ -49,7 +49,7 @@ final class PdoQuoteDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 
         // since php8 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         if (\count($args) < 1) {

--- a/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
@@ -19,6 +19,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
 
 final class PdoQuoteDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -47,8 +48,7 @@ final class PdoQuoteDynamicReturnTypeExtension implements DynamicMethodReturnTyp
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
@@ -74,8 +74,7 @@ final class PdoQuoteDynamicReturnTypeExtension implements DynamicMethodReturnTyp
             return $stringType;
         }
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
             return $stringType;
         }
 

--- a/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQuoteDynamicReturnTypeExtension.php
@@ -74,6 +74,11 @@ final class PdoQuoteDynamicReturnTypeExtension implements DynamicMethodReturnTyp
             return $stringType;
         }
 
+        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
+        if ($this->phpVersion->getVersionId() >= 80000) {
+            return $stringType;
+        }
+
         return TypeCombinator::union($stringType, new ConstantBooleanType(false));
     }
 

--- a/src/Extensions/PdoStatementColumnCountDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementColumnCountDynamicReturnTypeExtension.php
@@ -29,7 +29,6 @@ final class PdoStatementColumnCountDynamicReturnTypeExtension implements Dynamic
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
     {
-        $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
         $statementType = $scope->getType($methodCall->var);

--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -21,6 +21,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 
 final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension

--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -24,6 +24,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
 
 final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -52,8 +53,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
         $args = $methodCall->getArgs();
         $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
-        // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-        if ($this->phpVersion->getVersionId() >= 80000 && !$defaultReturn instanceof MixedType) {
+        if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion) && !$defaultReturn instanceof MixedType) {
             $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
@@ -99,8 +99,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
                     return new ArrayType(new IntegerType(), $builder->getArray());
                 }
 
-                // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-                if ($this->phpVersion->getVersionId() >= 80000) {
+                if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
                     return $builder->getArray();
                 }
 
@@ -111,8 +110,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
                 return new ArrayType(new IntegerType(), $resultType);
             }
 
-            // since php8 the default error mode changed to exception, therefore false returns are not longer possible
-            if ($this->phpVersion->getVersionId() >= 80000) {
+            if (QueryReflection::getRuntimeConfiguration()->throwsPdoExceptions($this->phpVersion)) {
                 return $resultType;
             }
 

--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -53,7 +53,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
 
         // since php8 the default error mode changed to exception, therefore false returns are not longer possible
         if ($this->phpVersion->getVersionId() >= 80000) {
-            TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
+            $defaultReturn = TypeCombinator::remove($defaultReturn, new ConstantBooleanType(false));
         }
 
         $statementType = $scope->getType($methodCall->var);

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -135,7 +135,7 @@ final class QueryReflection
         return null;
     }
 
-    static private function reflector(): QueryReflector
+    private static function reflector(): QueryReflector
     {
         if (null === self::$reflector) {
             throw new DbaException('Reflector not initialized, call '.__CLASS__.'::setupReflector() first');
@@ -144,12 +144,12 @@ final class QueryReflection
         return self::$reflector;
     }
 
-	static public function getRuntimeConfiguration() : RuntimeConfiguration
-	{
-		if (null === self::$runtimeConfiguration) {
-			throw new DbaException('Runtime configuration not initialized, call '.__CLASS__.'::setupReflector() first');
-		}
+    public static function getRuntimeConfiguration(): RuntimeConfiguration
+    {
+        if (null === self::$runtimeConfiguration) {
+            throw new DbaException('Runtime configuration not initialized, call '.__CLASS__.'::setupReflector() first');
+        }
 
-		return self::$runtimeConfiguration;
-	}
+        return self::$runtimeConfiguration;
+    }
 }

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -27,10 +27,15 @@ final class QueryReflection
      * @var QueryReflector|null
      */
     private static $reflector;
+    /**
+     * @var RuntimeConfiguration|null
+     */
+    private static $runtimeConfiguration;
 
-    public static function setupReflector(QueryReflector $reflector): void
+    public static function setupReflector(QueryReflector $reflector, RuntimeConfiguration $runtimeConfiguration): void
     {
         self::$reflector = $reflector;
+        self::$runtimeConfiguration = $runtimeConfiguration;
     }
 
     public function validateQueryString(string $queryString): ?Error
@@ -130,7 +135,7 @@ final class QueryReflection
         return null;
     }
 
-    private function reflector(): QueryReflector
+    static private function reflector(): QueryReflector
     {
         if (null === self::$reflector) {
             throw new DbaException('Reflector not initialized, call '.__CLASS__.'::setupReflector() first');
@@ -138,4 +143,13 @@ final class QueryReflection
 
         return self::$reflector;
     }
+
+	static public function getRuntimeConfiguration() : RuntimeConfiguration
+	{
+		if (null === self::$runtimeConfiguration) {
+			throw new DbaException('Runtime configuration not initialized, call '.__CLASS__.'::setupReflector() first');
+		}
+
+		return self::$runtimeConfiguration;
+	}
 }

--- a/src/QueryReflection/RuntimeConfiguration.php
+++ b/src/QueryReflection/RuntimeConfiguration.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\QueryReflection;
+
+use PHPStan\Php\PhpVersion;
+
+final class RuntimeConfiguration
+{
+    public const ERROR_MODE_EXCEPTION = 'exception';
+    public const ERROR_MODE_DEFAULT = 'default';
+
+    /**
+     * @var self::ERROR_MODE*
+     */
+    private $errorMode = self::ERROR_MODE_DEFAULT;
+
+    public static function create():self
+    {
+        return new self();
+    }
+
+    /**
+     * @param self::ERROR_MODE* $mode
+     */
+    public function errorMode($mode):self
+    {
+        $this->errorMode = $mode;
+
+		return $this;
+    }
+
+    public function throwsPdoExceptions(PhpVersion $phpVersion): bool
+    {
+        if (self::ERROR_MODE_EXCEPTION === $this->errorMode) {
+            return true;
+        }
+
+        // since php8 the pdo php-src default error mode changed to exception
+        return $phpVersion->getVersionId() >= 80000;
+    }
+
+    public function throwsMysqliExceptions(PhpVersion $phpVersion): bool
+    {
+        if (self::ERROR_MODE_EXCEPTION === $this->errorMode) {
+            return true;
+        }
+
+        // since php8.1 the mysqli php-src default error mode changed to exception
+        return $phpVersion->getVersionId() >= 80100;
+    }
+}

--- a/src/QueryReflection/RuntimeConfiguration.php
+++ b/src/QueryReflection/RuntimeConfiguration.php
@@ -16,7 +16,7 @@ final class RuntimeConfiguration
      */
     private $errorMode = self::ERROR_MODE_DEFAULT;
 
-    public static function create():self
+    public static function create(): self
     {
         return new self();
     }
@@ -24,11 +24,11 @@ final class RuntimeConfiguration
     /**
      * @param self::ERROR_MODE* $mode
      */
-    public function errorMode($mode):self
+    public function errorMode($mode): self
     {
         $this->errorMode = $mode;
 
-		return $this;
+        return $this;
     }
 
     public function throwsPdoExceptions(PhpVersion $phpVersion): bool

--- a/tests/data/mysqli-escape.php
+++ b/tests/data/mysqli-escape.php
@@ -50,9 +50,9 @@ class Foo
 
         // when quote() cannot return a numeric-string, we can't infer the precise result-type
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($s));
-        assertType('bool|mysqli_result', $result);
+        assertType('mysqli_result|true', $result);
 
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($nonE));
-        assertType('bool|mysqli_result', $result);
+        assertType('mysqli_result|true', $result);
     }
 }

--- a/tests/data/mysqli-escape.php
+++ b/tests/data/mysqli-escape.php
@@ -37,16 +37,16 @@ class Foo
     public function quotedArguments(mysqli $mysqli, int $i, float $f, $n, string $s, $nonE, string $numericString)
     {
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $i));
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>', $result);
 
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $f));
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>', $result);
 
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string((string) $n));
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>', $result);
 
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($numericString));
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>}>', $result);
 
         // when quote() cannot return a numeric-string, we can't infer the precise result-type
         $result = $mysqli->query('SELECT email, adaid FROM ada WHERE adaid='.$mysqli->real_escape_string($s));

--- a/tests/data/mysqli.php
+++ b/tests/data/mysqli.php
@@ -10,7 +10,7 @@ class Foo
     public function ooQuerySelected(mysqli $mysqli)
     {
         $result = $mysqli->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $result);
 
         if ($result) {
             foreach ($result as $row) {
@@ -31,7 +31,7 @@ class Foo
     public function fnQuerySelected(mysqli $mysqli)
     {
         $result = mysqli_query($mysqli, 'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
-        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>|false', $result);
+        assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $result);
 
         if ($result) {
             foreach ($result as $row) {

--- a/tests/data/mysqli.php
+++ b/tests/data/mysqli.php
@@ -12,13 +12,11 @@ class Foo
         $result = $mysqli->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
         assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $result);
 
-        if ($result) {
-            foreach ($result as $row) {
-                assertType('int<0, 4294967295>', $row['adaid']);
-                assertType('string', $row['email']);
-                assertType('int<-128, 127>', $row['gesperrt']);
-                assertType('int<-128, 127>', $row['freigabe1u1']);
-            }
+        foreach ($result as $row) {
+            assertType('int<0, 4294967295>', $row['adaid']);
+            assertType('string', $row['email']);
+            assertType('int<-128, 127>', $row['gesperrt']);
+            assertType('int<-128, 127>', $row['freigabe1u1']);
         }
     }
 
@@ -33,13 +31,11 @@ class Foo
         $result = mysqli_query($mysqli, 'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
         assertType('mysqli_result<array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $result);
 
-        if ($result) {
-            foreach ($result as $row) {
-                assertType('int<0, 4294967295>', $row['adaid']);
-                assertType('string', $row['email']);
-                assertType('int<-128, 127>', $row['gesperrt']);
-                assertType('int<-128, 127>', $row['freigabe1u1']);
-            }
+        foreach ($result as $row) {
+            assertType('int<0, 4294967295>', $row['adaid']);
+            assertType('string', $row['email']);
+            assertType('int<-128, 127>', $row['gesperrt']);
+            assertType('int<-128, 127>', $row['freigabe1u1']);
         }
     }
 

--- a/tests/data/mysqli.php
+++ b/tests/data/mysqli.php
@@ -25,7 +25,7 @@ class Foo
     public function ooQuery(mysqli $mysqli, string $query)
     {
         $result = $mysqli->query($query);
-        assertType('bool|mysqli_result', $result);
+        assertType('mysqli_result|true', $result);
     }
 
     public function fnQuerySelected(mysqli $mysqli)
@@ -46,6 +46,6 @@ class Foo
     public function fnQuery(mysqli $mysqli, string $query)
     {
         $result = mysqli_query($mysqli, $query);
-        assertType('bool|mysqli_result', $result);
+        assertType('mysqli_result|true', $result);
     }
 }

--- a/tests/data/pdo-fetch-types.php
+++ b/tests/data/pdo-fetch-types.php
@@ -26,9 +26,9 @@ class Foo
     public function unsupportedFetchTypes(PDO $pdo)
     {
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada', PDO::FETCH_COLUMN);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
 
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada', PDO::FETCH_OBJ);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 }

--- a/tests/data/pdo-quote.php
+++ b/tests/data/pdo-quote.php
@@ -43,12 +43,12 @@ class Foo
         assertType('string', $pdo->quote($s, PDO::PARAM_BOOL));
 
         // not 100% sure, whether LOB is really not supported across the board
-        assertType('numeric-string|false', $pdo->quote((string) $i, PDO::PARAM_LOB));
-        assertType('numeric-string|false', $pdo->quote((string) $f, PDO::PARAM_LOB));
-        assertType('numeric-string|false', $pdo->quote((string) $n, PDO::PARAM_LOB));
-        assertType('numeric-string|false', $pdo->quote($numericString, PDO::PARAM_LOB));
-        assertType('non-empty-string|false', $pdo->quote($nonE, PDO::PARAM_LOB));
-        assertType('string|false', $pdo->quote($s, PDO::PARAM_LOB));
+        assertType('numeric-string', $pdo->quote((string) $i, PDO::PARAM_LOB));
+        assertType('numeric-string', $pdo->quote((string) $f, PDO::PARAM_LOB));
+        assertType('numeric-string', $pdo->quote((string) $n, PDO::PARAM_LOB));
+        assertType('numeric-string', $pdo->quote($numericString, PDO::PARAM_LOB));
+        assertType('non-empty-string', $pdo->quote($nonE, PDO::PARAM_LOB));
+        assertType('string', $pdo->quote($s, PDO::PARAM_LOB));
     }
 
     /**
@@ -72,9 +72,9 @@ class Foo
 
         // when quote() cannot return a numeric-string, we can't infer the precise result-type
         $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote($s), PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
 
         $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$pdo->quote($nonE), PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 }

--- a/tests/data/pdo-stmt-fetch.php
+++ b/tests/data/pdo-stmt-fetch.php
@@ -28,7 +28,7 @@ class Foo
 
         // not yet supported fetch types
         $all = $stmt->fetchAll(PDO::FETCH_OBJ);
-        assertType('array|false', $all); // XXX since php8 this cannot return false
+        assertType('array', $all); // XXX since php8 this cannot return false
     }
 
     public function fetch(PDO $pdo)
@@ -39,16 +39,16 @@ class Foo
 
         // default fetch-mode is BOTH
         $all = $stmt->fetch();
-        assertType('array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}|false', $all);
+        assertType('array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}', $all);
 
         $all = $stmt->fetch(PDO::FETCH_BOTH);
-        assertType('array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}|false', $all);
+        assertType('array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}', $all);
 
         $all = $stmt->fetch(PDO::FETCH_NUM);
-        assertType('array{string, int<0, 4294967295>}|false', $all);
+        assertType('array{string, int<0, 4294967295>}', $all);
 
         $all = $stmt->fetch(PDO::FETCH_ASSOC);
-        assertType('array{email: string, adaid: int<0, 4294967295>}|false', $all);
+        assertType('array{email: string, adaid: int<0, 4294967295>}', $all);
 
         // not yet supported fetch types
         $all = $stmt->fetch(PDO::FETCH_OBJ);

--- a/tests/data/pdo.php
+++ b/tests/data/pdo.php
@@ -42,7 +42,7 @@ class Foo
     public function syntaxError(PDO $pdo)
     {
         $stmt = $pdo->query('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 
     /**
@@ -76,39 +76,39 @@ class Foo
         // ---- queries, for which we cannot infer the return type
 
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$string, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
 
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$nonEmptyString, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
 
         $stmt = $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE '.$mixed, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 
     public function dynamicQuery(PDO $pdo, string $query)
     {
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 
     public function insertQuery(PDO $pdo)
     {
         $query = "INSERT INTO ada SET email='test@complex-it.de'";
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 
     public function replaceQuery(PDO $pdo)
     {
         $query = "REPLACE INTO ada SET email='test@complex-it.de'";
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 
     public function updateQuery(PDO $pdo)
     {
         $query = "UPDATE ada SET email='test@complex-it.de' where adaid=-5";
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
-        assertType('PDOStatement<array>|false', $stmt);
+        assertType('PDOStatement<array>', $stmt);
     }
 }


### PR DESCRIPTION
see also https://github.com/php/doc-en/pull/1313

- when analyzing a php8+ codebase, [`PDO::ERRMODE_EXCEPTION` error handling](https://www.php.net/manual/en/pdo.error-handling.php) is assumed.
- when analyzing a php8.1+ codebase, [`mysqli_report(\MYSQLI_REPORT_ERROR | \MYSQLI_REPORT_STRICT);` error handling](https://www.php.net/mysqli_report) is assumed.
