### PR TITLE
Fix `RecordingQueryReflector` to work phpstan and phpunit in tandem

### DIFF
--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -9,10 +9,6 @@
          'message' => 'Unknown column \'doesNotExist\' in \'group statement\'',
          'code' => 1054,
       )),
-      'result' => 
-      array (
-        1 => NULL,
-      ),
     ),
     'SELECT * FROM ada ORDER BY doesNotExist' => 
     array (
@@ -21,10 +17,6 @@
          'message' => 'Unknown column \'doesNotExist\' in \'order clause\'',
          'code' => 1054,
       )),
-      'result' => 
-      array (
-        1 => NULL,
-      ),
     ),
     'SELECT * FROM ada WHERE doesNotExist=1' => 
     array (
@@ -33,10 +25,6 @@
          'message' => 'Unknown column \'doesNotExist\' in \'where clause\'',
          'code' => 1054,
       )),
-      'result' => 
-      array (
-        1 => NULL,
-      ),
     ),
     'SELECT * FROM unknownTable' => 
     array (
@@ -45,10 +33,6 @@
          'message' => 'Table \'phpstan_dba.unknownTable\' doesn\'t exist',
          'code' => 1146,
       )),
-      'result' => 
-      array (
-        1 => NULL,
-      ),
     ),
     'SELECT akid FROM ak WHERE eadavk>1.0' => 
     array (
@@ -139,10 +123,6 @@
          'message' => 'Unknown column \'doesNotExist\' in \'field list\'',
          'code' => 1054,
       )),
-      'result' => 
-      array (
-        1 => NULL,
-      ),
     ),
     'SELECT eladaid FROM ak' => 
     array (
@@ -213,8 +193,6 @@
       'result' => 
       array (
         1 => NULL,
-        2 => NULL,
-        3 => NULL,
       ),
     ),
     'SELECT email, adaid FROM ada' => 
@@ -616,59 +594,11 @@
         )),
       ),
     ),
-    'SELECT email, adaid FROM ada WHERE adaid = 1 and email = :email' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \':email LIMIT 0\' at line 1',
-         'code' => 1064,
-      )),
-      'result' => 
-      array (
-        3 => NULL,
-      ),
-    ),
-    'SELECT email, adaid FROM ada WHERE adaid = 1 and email = ?' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'? LIMIT 0\' at line 1',
-         'code' => 1064,
-      )),
-      'result' => 
-      array (
-        3 => NULL,
-      ),
-    ),
     'SELECT email, adaid FROM ada WHERE adaid = :adaid' => 
     array (
       'error' => 
       staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \':adaid LIMIT 0\' at line 1',
-         'code' => 1064,
-      )),
-      'result' => 
-      array (
-        3 => NULL,
-      ),
-    ),
-    'SELECT email, adaid FROM ada WHERE adaid = :adaid and email = \'email@example.org\'' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \':adaid and email = \'email@example.org\' LIMIT 0\' at line 1',
-         'code' => 1064,
-      )),
-      'result' => 
-      array (
-        3 => NULL,
-      ),
-    ),
-    'SELECT email, adaid FROM ada WHERE adaid = :adaid and email = :email' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \':adaid and email = :email LIMIT 0\' at line 1',
          'code' => 1064,
       )),
       'result' => 
@@ -979,6 +909,10 @@
         3 => NULL,
       ),
     ),
+    'SELECT email, adaid FROM ada WHERE gesperrt = 1' => 
+    array (
+      'error' => NULL,
+    ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada' => 
     array (
       'error' => NULL,
@@ -1072,90 +1006,6 @@
             )),
           ),
            'nextAutoIndex' => 0,
-           'optionalKeys' => 
-          array (
-          ),
-        )),
-        2 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -128,
-                 'max' => 4294967295,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-          )),
-           'allArrays' => NULL,
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-          ),
-           'nextAutoIndex' => 4,
            'optionalKeys' => 
           array (
           ),

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -21,7 +21,7 @@ try {
 	if (false !== getenv('GITHUB_ACTION')) {
 		$mysqli = @new mysqli('127.0.0.1', 'root', 'root', 'phpstan_dba');
 	} else {
-		$mysqli = @new mysqli('mysql80.ab', 'testuser', 'test', 'phpstan_dba');
+		$mysqli = new mysqli('mysql80.ab', 'testuser', 'test', 'phpstan_dba');
 	}
 
 	$reflector = new MysqliQueryReflector($mysqli);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,7 +9,12 @@ use staabm\PHPStanDba\QueryReflection\ReflectionCache;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$cacheFile = __DIR__.'/.phpstan-dba.cache';
+
+// use a separate cache file for each, phpstan and phpunit since both trigger different queries
+$cacheFile = __DIR__.'/.phpunit-phpstan-dba.cache';
+if (defined('__PHPSTAN_RUNNING__')) {
+    $cacheFile = __DIR__.'/.phpstan-dba.cache';
+}
 
 try {
 	if (false !== getenv('GITHUB_ACTION')) {
@@ -19,15 +24,12 @@ try {
 	}
 
 	$reflector = new MysqliQueryReflector($mysqli);
-	// record only while phpunit is running - since this file might also be used as phpstan bootscript
-	if (defined('__PHPSTAN_RUNNING__')) {
-		$reflector = new RecordingQueryReflector(
-			ReflectionCache::create(
-				$cacheFile
-			),
-			$reflector
-		);
-	}
+    $reflector = new RecordingQueryReflector(
+        ReflectionCache::create(
+            $cacheFile
+        ),
+        $reflector
+    );
 
 } catch (mysqli_sql_exception $e) {
 	if ($e->getCode() !== MysqliQueryReflector::MYSQL_HOST_NOT_FOUND) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,8 +9,9 @@ use staabm\PHPStanDba\QueryReflection\ReflectionCache;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-
-// use a separate cache file for each, phpstan and phpunit since both trigger different queries
+// we need to record the reflection information in both, phpunit and phpstan since we are replaying it in both CI jobs.
+// in a regular application you will use phpstan-dba only within your phpstan CI job, therefore you only need 1 cache-file.
+// phpstan-dba itself is a special case, since we are testing phpstan-dba with phpstan-dba.
 $cacheFile = __DIR__.'/.phpunit-phpstan-dba.cache';
 if (defined('__PHPSTAN_RUNNING__')) {
     $cacheFile = __DIR__.'/.phpstan-dba.cache';

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,7 +20,7 @@ try {
 
 	$reflector = new MysqliQueryReflector($mysqli);
 	// record only while phpunit is running - since this file might also be used as phpstan bootscript
-	if (!defined('__PHPSTAN_RUNNING__')) {
+	if (defined('__PHPSTAN_RUNNING__')) {
 		$reflector = new RecordingQueryReflector(
 			ReflectionCache::create(
 				$cacheFile


### PR DESCRIPTION
we need to record the reflection information in both, phpunit and phpstan since we are replaying it in both CI jobs.
in a regular application you will use phpstan-dba only within your phpstan CI job, therefore you only need 1 cache-file.
phpstan-dba itself is a special case, since we are testing phpstan-dba with phpstan-dba.