### PR TITLE
refactor `MysqliQueryReflector` to reduce numer of executed queries

### DIFF
--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -60,6 +60,64 @@
     array (
       'error' => NULL,
     ),
+    '
+            SELECT email adaid
+            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
+            FROM ada
+            LIMIT        1
+        ' => 
+    array (
+      'error' => 
+      staabm\PHPStanDba\Error::__set_state(array(
+         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
+         'code' => 1064,
+      )),
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT        \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT        \'1\',  \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT   \'1\',     \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
+            LIMIT        1
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\' AND email LIKE NULL
+            LIMIT        1
+        ' => 
+    array (
+      'error' => NULL,
+    ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 

--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -60,55 +60,6 @@
     array (
       'error' => NULL,
     ),
-    '
-            SELECT email adaid
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
-            FROM ada
-            LIMIT        1
-        ' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
-         'code' => 1064,
-      )),
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\',  \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE NULL
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 


### PR DESCRIPTION
before this change the test-suite required 121 queries to the database.
after this change we need only 32 queries, because we no longer re-issue already executed queries