### PR TITLE
Do not run PDO namedPlaceholders checks with question mark parameters

### DIFF
--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -122,15 +122,17 @@ final class PdoStatementExecuteMethodRule implements Rule
 
         $errors = [];
         $namedPlaceholders = $this->extractNamedPlaceholders($queryString);
-        foreach ($namedPlaceholders as $namedPlaceholder) {
-            if (!\array_key_exists($namedPlaceholder, $parameters)) {
-                $errors[] = RuleErrorBuilder::message(sprintf('Query expects placeholder %s, but it is missing from values given to execute().', $namedPlaceholder))->line($methodCall->getLine())->build();
+        if (\count($namedPlaceholders) > 0) {
+            foreach ($namedPlaceholders as $namedPlaceholder) {
+                if (!\array_key_exists($namedPlaceholder, $parameters)) {
+                    $errors[] = RuleErrorBuilder::message(sprintf('Query expects placeholder %s, but it is missing from values given to execute().', $namedPlaceholder))->line($methodCall->getLine())->build();
+                }
             }
-        }
 
-        foreach ($parameters as $placeholderKey => $value) {
-            if (!\in_array($placeholderKey, $namedPlaceholders)) {
-                $errors[] = RuleErrorBuilder::message(sprintf('Value %s is given to execute(), but the query does not contain this placeholder.', $placeholderKey))->line($methodCall->getLine())->build();
+            foreach ($parameters as $placeholderKey => $value) {
+                if (!\in_array($placeholderKey, $namedPlaceholders)) {
+                    $errors[] = RuleErrorBuilder::message(sprintf('Value %s is given to execute(), but the query does not contain this placeholder.', $placeholderKey))->line($methodCall->getLine())->build();
+                }
             }
         }
 


### PR DESCRIPTION
Adding a simple `if (\count($namedPlaceholders) > 0) {` around the **named** placeholders checks.

This stops the following error when checking `$stmt->execute()` on a query using question mark parameters.

    Value 0 is given to execute(), but the query does not contain this placeholder.

This is for [Issue 69](https://github.com/staabm/phpstan-dba/issues/69)