### PR TITLE
Add support for JSON columns and nullability for string column types

### DIFF
--- a/src/QueryReflection/MysqliQueryReflector.php
+++ b/src/QueryReflection/MysqliQueryReflector.php
@@ -216,28 +216,32 @@ final class MysqliQueryReflector implements QueryReflector
             $phpstanType = $mysqlIntegerRanges->unsignedInt();
         }
 
-        if ($phpstanType) {
-            if (false === $notNull) {
-                $phpstanType = TypeCombinator::addNull($phpstanType);
+        if (null === $phpstanType) {
+            switch ($this->type2txt($mysqlType)) {
+                case 'LONGLONG':
+                case 'LONG':
+                case 'SHORT':
+                    $phpstanType = new IntegerType();
+                    break;
+                case 'CHAR':
+                case 'STRING':
+                case 'VAR_STRING':
+                case 'JSON':
+                    $phpstanType = new StringType();
+                    break;
+                case 'DATE': // ???
+                case 'DATETIME': // ???
+
+                default:
+                    $phpstanType = new MixedType();
             }
-
-            return $phpstanType;
         }
 
-        switch ($this->type2txt($mysqlType)) {
-            case 'LONGLONG':
-            case 'LONG':
-            case 'SHORT':
-                return new IntegerType();
-            case 'CHAR':
-            case 'STRING':
-            case 'VAR_STRING':
-                return new StringType();
-            case 'DATE': // ???
-            case 'DATETIME': // ???
+        if (false === $notNull) {
+            $phpstanType = TypeCombinator::addNull($phpstanType);
         }
 
-        return new MixedType();
+        return $phpstanType;
     }
 
     private function type2txt(int $typeId): ?string

--- a/src/QueryReflection/MysqliQueryReflector.php
+++ b/src/QueryReflection/MysqliQueryReflector.php
@@ -231,7 +231,6 @@ final class MysqliQueryReflector implements QueryReflector
                     break;
                 case 'DATE': // ???
                 case 'DATETIME': // ???
-
                 default:
                     $phpstanType = new MixedType();
             }


### PR DESCRIPTION
While I'm here, for DATE/DATETIME I guess string is also the only reasonable output.. unless PHPStan has a concept of date-string (which would be kinda neat;)