### PR TITLE
Added initial Doctrine Dbal type inference

### DIFF
--- a/.phpstan-dba.cache
+++ b/.phpstan-dba.cache
@@ -213,6 +213,7 @@
       'result' => 
       array (
         1 => NULL,
+        2 => NULL,
         3 => NULL,
       ),
     ),
@@ -983,28 +984,44 @@
       'error' => NULL,
       'result' => 
       array (
-        1 => 
+        3 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                  'value' => 'adaid',
                  'isClassString' => false,
               )),
-              1 => 
+              5 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                  'value' => 'email',
                  'isClassString' => false,
               )),
-              2 => 
+              6 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                  'value' => 'freigabe1u1',
                  'isClassString' => false,
               )),
-              3 => 
+              7 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                  'value' => 'gesperrt',
                  'isClassString' => false,
@@ -1034,19 +1051,35 @@
                'isClassString' => false,
             )),
             1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
             )),
-            2 => 
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+            4 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
             )),
-            3 => 
+            5 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 2,
+            )),
+            6 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+            )),
+            7 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
             )),
           ),
            'valueTypes' => 
@@ -1055,22 +1088,40 @@
             PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
             PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => 0,
                'max' => 4294967295,
             )),
-            2 => 
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            4 => 
             PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
-            3 => 
+            5 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            6 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            7 => 
             PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
           ),
-           'nextAutoIndex' => 0,
+           'nextAutoIndex' => 4,
            'optionalKeys' => 
           array (
           ),

--- a/.phpstan-dba.cache
+++ b/.phpstan-dba.cache
@@ -1126,6 +1126,182 @@
           array (
           ),
         )),
+        1 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+              )),
+            ),
+          )),
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -128,
+                 'max' => 4294967295,
+              )),
+              1 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+          )),
+           'allArrays' => NULL,
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+          ),
+           'nextAutoIndex' => 0,
+           'optionalKeys' => 
+          array (
+          ),
+        )),
+        2 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+            ),
+          )),
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -128,
+                 'max' => 4294967295,
+              )),
+              1 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+          )),
+           'allArrays' => NULL,
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 2,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+          ),
+           'nextAutoIndex' => 4,
+           'optionalKeys' => 
+          array (
+          ),
+        )),
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada LIMIT 1' => 

--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -60,64 +60,6 @@
     array (
       'error' => NULL,
     ),
-    '
-            SELECT email adaid
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
-            FROM ada
-            LIMIT        1
-        ' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
-         'code' => 1064,
-      )),
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\',  \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT   \'1\',     \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE NULL
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 

--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -1034,6 +1034,148 @@
       'error' => NULL,
       'result' => 
       array (
+        3 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+              )),
+              5 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+              )),
+              6 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+              )),
+              7 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+              )),
+            ),
+          )),
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -128,
+                 'max' => 4294967295,
+              )),
+              1 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+          )),
+           'allArrays' => NULL,
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+            4 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+            )),
+            5 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 2,
+            )),
+            6 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+            )),
+            7 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            4 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            5 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            6 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            7 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+          ),
+           'nextAutoIndex' => 4,
+           'optionalKeys' => 
+          array (
+          ),
+        )),
         1 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'keyType' => 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This extension provides following features:
     * `Doctrine\DBAL\Result->fetchAssociative()`
     * `Doctrine\DBAL\Result->fetchAllNumeric()`
     * `Doctrine\DBAL\Result->fetchAllAssociative()`
+    * `Doctrine\DBAL\Result->columnCount()`
     * `mysqli->query`
     * `PDOStatement->fetch`
     * `PDOStatement->fetchAll`

--- a/README.md
+++ b/README.md
@@ -6,9 +6,20 @@ Additionally errors in code handling the results of sql queries can be detected.
 
 This extension provides following features:
 
-* the array shape of results can be inferred for `PDOStatement` and `mysqli_result`
+* the array shape of results can be inferred for `Doctrine\DBAL\Result`, `PDOStatement` and `mysqli_result`
   * .. when the query string can be resolved at analysis time. This is even possible for queries containing php-variables, as long as their typ is known in most cases.
-  * builtin we support `mysqli_query`, `mysqli->query`, `PDOStatement->fetch`, `PDOStatement->fetchAll`, `PDOStatement->execute`, `PDO->query` and `PDO->prepare`
+  * builtin we support
+    * `Doctrine\DBAL\Connection->query()`
+    * `Doctrine\DBAL\Result->fetchNumeric()`
+    * `Doctrine\DBAL\Result->fetchAssociative()`
+    * `Doctrine\DBAL\Result->fetchAllNumeric()`
+    * `Doctrine\DBAL\Result->fetchAllAssociative()`
+    * `mysqli->query`
+    * `PDOStatement->fetch`
+    * `PDOStatement->fetchAll`
+    * `PDOStatement->execute`
+    * `PDO->query`
+    * `PDO->prepare`
 * `SyntaxErrorInPreparedStatementMethodRule` can inspect prepared sql queries and detect syntax errors
 * `SyntaxErrorInQueryMethodRule` can inspect sql queries and detect syntax errors - `SyntaxErrorInQueryFunctionRule` can do the same for functions
   * builtin is query syntax error detection for `mysqli_query`, `mysqli->query`, `PDO->query` and `PDO->prepare`

--- a/config/DoctrineDbal.stub
+++ b/config/DoctrineDbal.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+/**
+ * @template TValue
+ */
+class Result
+{
+}

--- a/config/extensions.neon
+++ b/config/extensions.neon
@@ -5,6 +5,11 @@ services:
         	- phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: staabm\PHPStanDba\Extensions\DoctrineResultDynamicReturnTypeExtension
+        tags:
+        	- phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: staabm\PHPStanDba\Extensions\PdoQueryDynamicReturnTypeExtension
         tags:
         	- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/config/extensions.neon
+++ b/config/extensions.neon
@@ -1,5 +1,10 @@
 services:
     -
+        class: staabm\PHPStanDba\Extensions\DoctrineConnectionDynamicReturnTypeExtension
+        tags:
+        	- phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: staabm\PHPStanDba\Extensions\PdoQueryDynamicReturnTypeExtension
         tags:
         	- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/config/stubFiles.neon
+++ b/config/stubFiles.neon
@@ -1,4 +1,5 @@
 parameters:
     stubFiles:
+        - DoctrineDbal.stub
         - PdoStatement.stub
         - Mysqli.stub

--- a/src/Extensions/DoctrineConnectionDynamicReturnTypeExtension.php
+++ b/src/Extensions/DoctrineConnectionDynamicReturnTypeExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Extensions;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Result;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
+
+final class DoctrineConnectionDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Connection::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return 'query' === $methodReflection->getName();
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $args = $methodCall->getArgs();
+        $defaultReturn = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $methodCall->getArgs(),
+            $methodReflection->getVariants(),
+        )->getReturnType();
+
+        if (\count($args) < 1) {
+            return $defaultReturn;
+        }
+
+        $resultType = $this->inferType($methodCall, $args[0]->value, $scope);
+        if (null !== $resultType) {
+            return $resultType;
+        }
+
+        return $defaultReturn;
+    }
+
+    private function inferType(MethodCall $methodCall, Expr $queryExpr, Scope $scope): ?Type
+    {
+        $args = $methodCall->getArgs();
+
+        $queryReflection = new QueryReflection();
+        $queryString = $queryReflection->resolveQueryString($queryExpr, $scope);
+        if (null === $queryString) {
+            return null;
+        }
+
+        $resultType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_BOTH);
+        if ($resultType) {
+            return new GenericObjectType(Result::class, [$resultType]);
+        }
+
+        return null;
+    }
+}

--- a/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
+++ b/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
@@ -17,7 +17,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
@@ -91,7 +91,7 @@ final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodRet
             }
 
             if (\in_array(strtolower($methodReflection->getName()), ['fetchallnumeric', 'fetchallassociative'], true)) {
-                return new ArrayType(new IntegerType(), $builder->getArray());
+                return new ArrayType(IntegerRangeType::fromInterval(0, null), $builder->getArray());
             }
 
             return $builder->getArray();

--- a/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
+++ b/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Extensions;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Result;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
+
+final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Result::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array(strtolower($methodReflection->getName()), ['fetchnumeric'], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $defaultReturn = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+        $resultType = $scope->getType($methodCall->var);
+
+        if (!$resultType instanceof GenericObjectType) {
+            return $defaultReturn;
+        }
+
+        $genericTypes = $resultType->getTypes();
+
+        if (1 !== \count($genericTypes)) {
+            return $defaultReturn;
+        }
+
+        switch(strtolower($methodReflection->getName())) {
+            case 'fetchnumeric':
+                $fetchType = QueryReflector::FETCH_TYPE_NUMERIC;
+                break;
+            default:
+                $fetchType = QueryReflector::FETCH_TYPE_BOTH;
+        }
+
+        $resultType = $genericTypes[0];
+
+        if ((QueryReflector::FETCH_TYPE_NUMERIC === $fetchType || QueryReflector::FETCH_TYPE_ASSOC === $fetchType) && $resultType instanceof ConstantArrayType) {
+            $builder = ConstantArrayTypeBuilder::createEmpty();
+
+            $keyTypes = $resultType->getKeyTypes();
+            $valueTypes = $resultType->getValueTypes();
+
+            foreach ($keyTypes as $i => $keyType) {
+                if (QueryReflector::FETCH_TYPE_NUMERIC === $fetchType && $keyType instanceof ConstantIntegerType) {
+                    $builder->setOffsetValueType($keyType, $valueTypes[$i]);
+                } elseif (QueryReflector::FETCH_TYPE_ASSOC === $fetchType && $keyType instanceof ConstantStringType) {
+                    $builder->setOffsetValueType($keyType, $valueTypes[$i]);
+                }
+            }
+
+            return new ArrayType(new IntegerType(), $builder->getArray());
+        }
+
+        return $resultType;
+    }
+}

--- a/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
+++ b/src/Extensions/DoctrineResultDynamicReturnTypeExtension.php
@@ -4,23 +4,18 @@ declare(strict_types=1);
 
 namespace staabm\PHPStanDba\Extensions;
 
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Result;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
-use staabm\PHPStanDba\QueryReflection\QueryReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -32,7 +27,7 @@ final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodRet
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return in_array(strtolower($methodReflection->getName()), ['fetchnumeric'], true);
+        return \in_array(strtolower($methodReflection->getName()), ['fetchnumeric', 'fetchassociative'], true);
     }
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
@@ -51,9 +46,12 @@ final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodRet
             return $defaultReturn;
         }
 
-        switch(strtolower($methodReflection->getName())) {
+        switch (strtolower($methodReflection->getName())) {
             case 'fetchnumeric':
                 $fetchType = QueryReflector::FETCH_TYPE_NUMERIC;
+                break;
+            case 'fetchassociative':
+                $fetchType = QueryReflector::FETCH_TYPE_ASSOC;
                 break;
             default:
                 $fetchType = QueryReflector::FETCH_TYPE_BOTH;
@@ -75,7 +73,7 @@ final class DoctrineResultDynamicReturnTypeExtension implements DynamicMethodRet
                 }
             }
 
-            return new ArrayType(new IntegerType(), $builder->getArray());
+            return $builder->getArray();
         }
 
         return $resultType;

--- a/tests/DbaInferenceTest.php
+++ b/tests/DbaInferenceTest.php
@@ -8,6 +8,8 @@ class DbaInferenceTest extends TypeInferenceTestCase
 {
     public function dataFileAsserts(): iterable
     {
+        yield from $this->gatherAssertTypes(__DIR__.'/data/doctrine-dbal.php');
+
         // make sure class constants can be resolved
         require_once __DIR__.'/data/pdo.php';
         yield from $this->gatherAssertTypes(__DIR__.'/data/pdo.php');

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -17,5 +17,11 @@ class Foo
 
         $numericFetch = $result->fetchAssociative();
         assertType('array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}', $numericFetch);
+
+        $numericFetch = $result->fetchAllNumeric();
+        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $numericFetch);
+
+        $numericFetch = $result->fetchAllAssociative();
+        assertType('array<int, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $numericFetch);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -19,10 +19,10 @@ class Foo
         assertType('array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}', $fetch);
 
         $fetch = $result->fetchAllNumeric();
-        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $fetch);
+        assertType('array<int<0, max>, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $fetch);
 
         $fetch = $result->fetchAllAssociative();
-        assertType('array<int, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $fetch);
+        assertType('array<int<0, max>, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $fetch);
 
         $columnCount = $result->columnCount();
         assertType('4', $columnCount);

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DoctrineDbalTest;
+
+use Doctrine\DBAL\Driver\Connection;
+use function PHPStan\Testing\assertType;
+
+class Foo {
+    public function foo(Connection $conn) {
+        $result = $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
+        assertType('Doctrine\DBAL\ResultDoctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
+    }
+}

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -8,6 +8,6 @@ use function PHPStan\Testing\assertType;
 class Foo {
     public function foo(Connection $conn) {
         $result = $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
-        assertType('Doctrine\DBAL\ResultDoctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
+        assertType('Doctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -12,16 +12,16 @@ class Foo
         $result = $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
         assertType('Doctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
 
-        $numericFetch = $result->fetchNumeric();
-        assertType('array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}', $numericFetch);
+        $fetch = $result->fetchNumeric();
+        assertType('array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}', $fetch);
 
-        $numericFetch = $result->fetchAssociative();
-        assertType('array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}', $numericFetch);
+        $fetch = $result->fetchAssociative();
+        assertType('array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}', $fetch);
 
-        $numericFetch = $result->fetchAllNumeric();
-        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $numericFetch);
+        $fetch = $result->fetchAllNumeric();
+        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $fetch);
 
-        $numericFetch = $result->fetchAllAssociative();
-        assertType('array<int, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $numericFetch);
+        $fetch = $result->fetchAllAssociative();
+        assertType('array<int, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $fetch);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -13,6 +13,9 @@ class Foo
         assertType('Doctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
 
         $numericFetch = $result->fetchNumeric();
-        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $numericFetch);
+        assertType('array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}', $numericFetch);
+
+        $numericFetch = $result->fetchAssociative();
+        assertType('array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}', $numericFetch);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -23,5 +23,8 @@ class Foo
 
         $fetch = $result->fetchAllAssociative();
         assertType('array<int, array{email: string, adaid: int<0, 4294967295>, gesperrt: int<-128, 127>, freigabe1u1: int<-128, 127>}>', $fetch);
+
+        $columnCount = $result->columnCount();
+        assertType('4', $columnCount);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -11,5 +11,8 @@ class Foo
     {
         $result = $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
         assertType('Doctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
+
+        $numericFetch = $result->fetchNumeric();
+        assertType('array<int, array{string, int<0, 4294967295>, int<-128, 127>, int<-128, 127>}>', $numericFetch);
     }
 }

--- a/tests/data/doctrine-dbal.php
+++ b/tests/data/doctrine-dbal.php
@@ -5,8 +5,10 @@ namespace DoctrineDbalTest;
 use Doctrine\DBAL\Driver\Connection;
 use function PHPStan\Testing\assertType;
 
-class Foo {
-    public function foo(Connection $conn) {
+class Foo
+{
+    public function foo(Connection $conn)
+    {
         $result = $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
         assertType('Doctrine\DBAL\Result<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>, gesperrt: int<-128, 127>, 2: int<-128, 127>, freigabe1u1: int<-128, 127>, 3: int<-128, 127>}>', $result);
     }


### PR DESCRIPTION
refs https://github.com/staabm/phpstan-dba/issues/94

adds support for
- `Connection->query()`
- `Result->fetchNumeric()`
- `Result->fetchAssociative()`
- `Result->fetchAllNumeric()`
- `Result->fetchAllAssociative()`
- `Result->columnCount()`