### PR TITLE
Detect syntax errors in `Doctrine\DBAL\Connection::execute*()` methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 indent_style = space
 
-[*.{php,phpt}]
-indent_size = 4
-
-[*.neon]
+[*.{neon, md, php,phpt}]
 indent_size = 4
 
 [*.{yaml,yml}]

--- a/.phpstan-dba.cache
+++ b/.phpstan-dba.cache
@@ -213,6 +213,7 @@
       'result' => 
       array (
         1 => NULL,
+        2 => NULL,
         3 => NULL,
       ),
     ),
@@ -1071,6 +1072,90 @@
             )),
           ),
            'nextAutoIndex' => 0,
+           'optionalKeys' => 
+          array (
+          ),
+        )),
+        2 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+            ),
+          )),
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -128,
+                 'max' => 4294967295,
+              )),
+              1 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+          )),
+           'allArrays' => NULL,
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 2,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+          ),
+           'nextAutoIndex' => 4,
            'optionalKeys' => 
           array (
           ),

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ Reuse the `SyntaxErrorInPreparedStatementMethodRule` within your PHPStan configu
 
 ```
 services:
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			classMethods:
-				- 'My\Connection::preparedQuery'
-				- 'My\PreparedStatement::__construct'
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'My\Connection::preparedQuery'
+                - 'My\PreparedStatement::__construct'
 ```
 
 __the callable format is `class::method`. phpstan-dba assumes the method takes a query-string as a 1st and the parameter-values as a 2nd argument.__
@@ -154,13 +154,13 @@ Reuse the `SyntaxErrorInQueryMethodRule` within your PHPStan configuration to de
 
 ```
 services:
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryMethodRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			classMethods:
-				- 'myClass::query#0'
-				- 'anotherClass::takesAQuery#2'
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'myClass::query#0'
+                - 'anotherClass::takesAQuery#2'
 ```
 
 __the callable format is `class::method#parameterIndex`, while the parameter-index defines the position of the query-string argument.__
@@ -171,12 +171,12 @@ Reuse the `SyntaxErrorInQueryFunctionRule` within your PHPStan configuration to 
 
 ```
 services:
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryFunctionRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			functionNames:
-				- 'Deployer\runMysqlQuery#0'
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryFunctionRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            functionNames:
+                - 'Deployer\runMysqlQuery#0'
 ```
 
 __the callable format is `funtionName#parameterIndex`, while the parameter-index defines the position of the query-string argument.__

--- a/config/dba.neon
+++ b/config/dba.neon
@@ -1,26 +1,35 @@
 includes:
-	- stubFiles.neon
-	- extensions.neon
+    - stubFiles.neon
+    - extensions.neon
 
 services:
-	-
-		class: staabm\PHPStanDba\Rules\PdoStatementExecuteMethodRule
-		tags: [phpstan.rules.rule]
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'Doctrine\DBAL\Connection::executeQuery'
+                - 'Doctrine\DBAL\Connection::executeCacheQuery'
+                - 'Doctrine\DBAL\Connection::executeStatement'
 
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryMethodRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			classMethods:
-				- 'PDO::query#0'
-				- 'PDO::prepare#0'
-				- 'mysqli::query#0'
-				- 'Doctrine\DBAL\Connection::query#0'
+    -
+        class: staabm\PHPStanDba\Rules\PdoStatementExecuteMethodRule
+        tags: [phpstan.rules.rule]
 
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryFunctionRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			functionNames:
-				- 'Deployer\runMysqlQuery#0'
-				- 'mysqli_query#1'
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'PDO::query#0'
+                - 'PDO::prepare#0'
+                - 'mysqli::query#0'
+                - 'Doctrine\DBAL\Connection::query#0'
+
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryFunctionRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            functionNames:
+                - 'Deployer\runMysqlQuery#0'
+                - 'mysqli_query#1'

--- a/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
+++ b/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
@@ -38,15 +38,15 @@ class SyntaxErrorInPreparedStatementMethodRuleTest extends AbstractServiceAwareR
                 29,
             ],
             [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 104,
             ],
             [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 105,
             ],
             [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 106,
             ],
         ]);

--- a/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
+++ b/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
@@ -39,15 +39,15 @@ class SyntaxErrorInPreparedStatementMethodRuleTest extends AbstractServiceAwareR
             ],
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
-                104,
-            ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 105,
             ],
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 106,
+            ],
+            [
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
+                107,
             ],
         ]);
     }

--- a/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
+++ b/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
@@ -37,6 +37,18 @@ class SyntaxErrorInPreparedStatementMethodRuleTest extends AbstractServiceAwareR
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
                 29,
             ],
+            [
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                104,
+            ],
+            [
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                105,
+            ],
+            [
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 3 (1064).",
+                106,
+            ],
         ]);
     }
 }

--- a/tests/config/syntax-error-in-prepared-statement.neon
+++ b/tests/config/syntax-error-in-prepared-statement.neon
@@ -1,12 +1,15 @@
 includes:
-	- ../../config/stubFiles.neon
-	- ../../config/extensions.neon
+    - ../../config/stubFiles.neon
+    - ../../config/extensions.neon
 
 services:
-	-
-		class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
-		tags: [phpstan.rules.rule]
-		arguments:
-			classMethods:
-				- 'staabm\PHPStanDba\Tests\Fixture\Connection::preparedQuery'
-				- 'staabm\PHPStanDba\Tests\Fixture\PreparedStatement::__construct'
+    -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'staabm\PHPStanDba\Tests\Fixture\Connection::preparedQuery'
+                - 'staabm\PHPStanDba\Tests\Fixture\PreparedStatement::__construct'
+                - 'Doctrine\DBAL\Connection::executeQuery'
+                - 'Doctrine\DBAL\Connection::executeCacheQuery'
+                - 'Doctrine\DBAL\Connection::executeStatement'

--- a/tests/data/syntax-error-in-prepared-statement.php
+++ b/tests/data/syntax-error-in-prepared-statement.php
@@ -99,4 +99,10 @@ class Foo
     {
         $connection->preparedQuery('SELECT email, adaid FROM ada WHERE gesperrt = :myGesperrt', ['myGesperrt' => 1]);
     }
+
+    public function syntaxErrorInDoctrineDbal(\Doctrine\DBAL\Connection $conn) {
+        $conn->executeQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
+        $conn->executeCacheQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
+        $conn->executeStatement('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
+    }
 }

--- a/tests/data/syntax-error-in-prepared-statement.php
+++ b/tests/data/syntax-error-in-prepared-statement.php
@@ -100,7 +100,8 @@ class Foo
         $connection->preparedQuery('SELECT email, adaid FROM ada WHERE gesperrt = :myGesperrt', ['myGesperrt' => 1]);
     }
 
-    public function syntaxErrorInDoctrineDbal(\Doctrine\DBAL\Connection $conn, $types, \Doctrine\DBAL\Cache\QueryCacheProfile $qcp) {
+    public function syntaxErrorInDoctrineDbal(\Doctrine\DBAL\Connection $conn, $types, \Doctrine\DBAL\Cache\QueryCacheProfile $qcp)
+    {
         $conn->executeQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
         $conn->executeCacheQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', [], $types, $qcp);
         $conn->executeStatement('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);

--- a/tests/data/syntax-error-in-prepared-statement.php
+++ b/tests/data/syntax-error-in-prepared-statement.php
@@ -100,9 +100,9 @@ class Foo
         $connection->preparedQuery('SELECT email, adaid FROM ada WHERE gesperrt = :myGesperrt', ['myGesperrt' => 1]);
     }
 
-    public function syntaxErrorInDoctrineDbal(\Doctrine\DBAL\Connection $conn) {
+    public function syntaxErrorInDoctrineDbal(\Doctrine\DBAL\Connection $conn, $types, \Doctrine\DBAL\Cache\QueryCacheProfile $qcp) {
         $conn->executeQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
-        $conn->executeCacheQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
+        $conn->executeCacheQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', [], $types, $qcp);
         $conn->executeStatement('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', []);
     }
 }


### PR DESCRIPTION
This adds support for `executeQuery($sql, $params)`, `executeCacheQuery($sql, $params)`, `executeStatement($sql, $params)` 

`prepare($sql)` is not yet supported and can be implemented later

refs https://github.com/staabm/phpstan-dba/issues/94