### PR TITLE
doctrine dbal: cover deprecated api

### DIFF
--- a/.phpstan-dba.cache
+++ b/.phpstan-dba.cache
@@ -213,7 +213,6 @@
       'result' => 
       array (
         1 => NULL,
-        2 => NULL,
         3 => NULL,
       ),
     ),
@@ -1072,90 +1071,6 @@
             )),
           ),
            'nextAutoIndex' => 0,
-           'optionalKeys' => 
-          array (
-          ),
-        )),
-        2 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -128,
-                 'max' => 4294967295,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-          )),
-           'allArrays' => NULL,
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-          ),
-           'nextAutoIndex' => 4,
            'optionalKeys' => 
           array (
           ),

--- a/config/dba.neon
+++ b/config/dba.neon
@@ -11,6 +11,7 @@ services:
                 - 'Doctrine\DBAL\Connection::executeQuery'
                 - 'Doctrine\DBAL\Connection::executeCacheQuery'
                 - 'Doctrine\DBAL\Connection::executeStatement'
+                - 'Doctrine\DBAL\Connection::executeUpdate' # deprecated in doctrine
 
     -
         class: staabm\PHPStanDba\Rules\PdoStatementExecuteMethodRule
@@ -24,7 +25,8 @@ services:
                 - 'PDO::query#0'
                 - 'PDO::prepare#0'
                 - 'mysqli::query#0'
-                - 'Doctrine\DBAL\Connection::query#0'
+                - 'Doctrine\DBAL\Connection::query#0' # deprecated in doctrine
+                - 'Doctrine\DBAL\Connection::exec#0' # deprecated in doctrine
 
     -
         class: staabm\PHPStanDba\Rules\SyntaxErrorInQueryFunctionRule


### PR DESCRIPTION
since we just need a few lines of config, we also cover the deprecated api.

> This API is deprecated and will be removed after 2022