### PR TITLE
Skip queries containing placeholders in `SyntaxErrorInQueryMethodRule`

### DIFF
--- a/.phpunit-phpstan-dba.cache
+++ b/.phpunit-phpstan-dba.cache
@@ -60,6 +60,64 @@
     array (
       'error' => NULL,
     ),
+    '
+            SELECT email adaid
+            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
+            FROM ada
+            LIMIT        1
+        ' => 
+    array (
+      'error' => 
+      staabm\PHPStanDba\Error::__set_state(array(
+         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
+         'code' => 1064,
+      )),
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT        \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT        \'1\',  \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\'
+            LIMIT   \'1\',     \'1\'
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
+            LIMIT        1
+        ' => 
+    array (
+      'error' => NULL,
+    ),
+    '
+            SELECT email, adaid
+            FROM ada
+            WHERE gesperrt = \'1\' AND email LIKE NULL
+            LIMIT        1
+        ' => 
+    array (
+      'error' => NULL,
+    ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 
@@ -1508,6 +1566,14 @@
           ),
         )),
       ),
+    ),
+    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid=?' => 
+    array (
+      'error' => 
+      staabm\PHPStanDba\Error::__set_state(array(
+         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'? LIMIT 0\' at line 1',
+         'code' => 1064,
+      )),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE email=\'foo\'' => 
     array (

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -40,6 +40,11 @@ final class QueryReflection
             return null;
         }
 
+        // this method cannot validate queries which contain placeholders.
+        if (0 !== $this->countPlaceholders($queryString)) {
+            return null;
+        }
+
         return self::reflector()->validateQueryString($queryString);
     }
 

--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -12,7 +12,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
 

--- a/tests/data/syntax-error-in-query.php
+++ b/tests/data/syntax-error-in-query.php
@@ -70,6 +70,12 @@ class Foo
     public function syntaxErrorDoctrineDbal(\Doctrine\DBAL\Connection $conn)
     {
         $sql = 'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada';
-        $stmt = $conn->query($sql);
+        $conn->query($sql);
+    }
+
+    public function noErrorOnQueriesContainingPlaceholders(\Doctrine\DBAL\Connection $conn)
+    {
+        // errors in this scenario are reported by SyntaxErrorInPreparedStatementMethodRule only
+        $conn->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid=?');
     }
 }


### PR DESCRIPTION
in hybrid apis which support both, prepared and regular statements, a user might configure `SyntaxErrorInQueryMethodRule` and `SyntaxErrorInPreparedStatementMethodRule` in tandem for a single method.

we need to make sure that `SyntaxErrorInQueryMethodRule` will not error for queries, which contain placeholders in this case.

refs https://github.com/staabm/phpstan-dba/issues/106#issuecomment-1014633286