### PR TITLE
mark phpstan-dba cache files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.phpstan-dba.cache linguist-generated=true
+.phpunit-phpstan-dba.cache linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ This might be usefull if your CI pipeline cannot connect to your development dat
 
 The GitHubActions setup of `phpstan-dba` is [using this technique to replay the reflection information](https://github.com/staabm/phpstan-dba/blob/main/bootstrap.php).
 
+**Note**: In case you commit the generated cache files into your repository, consider [marking them as generated files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github), so they don't show up in Pull Requests.
+
 ### use `SyntaxErrorInPreparedStatementMethodRule` for your custom classes
 
 Reuse the `SyntaxErrorInPreparedStatementMethodRule` within your PHPStan configuration to detect syntax errors in prepared queries, by registering a service:


### PR DESCRIPTION
so they don't show up as diff in pull requests

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

closes https://github.com/staabm/phpstan-dba/issues/155