### PR TITLE
doctrine-dbal: remove `iterateAllNumeric` from `Connection`

### DIFF
--- a/src/Extensions/DoctrineConnectionFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/DoctrineConnectionFetchDynamicReturnTypeExtension.php
@@ -28,7 +28,7 @@ final class DoctrineConnectionFetchDynamicReturnTypeExtension implements Dynamic
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return \in_array(strtolower($methodReflection->getName()), ['fetchone', 'fetchfirstcolumn', 'fetchassociative', 'fetchallassociative', 'fetchnumeric', 'fetchallnumeric', 'iteratecolumn', 'iterateassociative', 'iteratenumeric', 'iterateallnumeric'], true);
+        return \in_array(strtolower($methodReflection->getName()), ['fetchone', 'fetchfirstcolumn', 'fetchassociative', 'fetchallassociative', 'fetchnumeric', 'fetchallnumeric', 'iteratecolumn', 'iterateassociative', 'iteratenumeric'], true);
     }
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type


### PR DESCRIPTION
there is no `iterateAllNumeric` method in the api