### PR TITLE
validate parameter count only with unnamed placeholders

### DIFF
--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -357,6 +357,26 @@ final class QueryReflection
     }
 
     /**
+     * @param array<string|int, Parameter> $parameters
+     */
+    public function containsNamedPlaceholders(string $queryString, array $parameters): bool
+    {
+        $namedPlaceholders = $this->extractNamedPlaceholders($queryString);
+
+        if ([] !== $namedPlaceholders) {
+            return true;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (null !== $parameter->name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return list<string>
      */
     public function extractNamedPlaceholders(string $queryString): array

--- a/tests/PdoStatementExecuteMethodRuleTest.php
+++ b/tests/PdoStatementExecuteMethodRuleTest.php
@@ -48,7 +48,7 @@ class PdoStatementExecuteMethodRuleTest extends AbstractServiceAwareRuleTestCase
             ],
             */
             [
-                'Query expects 1 placeholder, but no values are given.',
+                'Query expects placeholder :adaid, but it is missing from values given.',
                 21,
             ],
             [
@@ -56,11 +56,11 @@ class PdoStatementExecuteMethodRuleTest extends AbstractServiceAwareRuleTestCase
                 24,
             ],
             [
-                'Query expects 2 placeholders, but 1 value is given.',
+                'Query expects placeholder :email, but it is missing from values given.',
                 27,
             ],
             [
-                'Query expects 2 placeholders, but 1 value is given.',
+                'Query expects placeholder :adaid, but it is missing from values given.',
                 30,
             ],
             [
@@ -72,7 +72,7 @@ class PdoStatementExecuteMethodRuleTest extends AbstractServiceAwareRuleTestCase
                 36,
             ],
             [
-                'Query expects 1 placeholder, but 2 values are given.',
+                'Value :email is given, but the query does not contain this placeholder.',
                 38,
             ],
             [

--- a/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
+++ b/tests/SyntaxErrorInPreparedStatementMethodRuleTest.php
@@ -61,10 +61,6 @@ class SyntaxErrorInPreparedStatementMethodRuleTest extends AbstractServiceAwareR
                 'Query expects placeholder :name, but it is missing from values given.',
                 307,
             ],
-            [
-                'Query expects 2 placeholders, but 0-1 values are given.',
-                307,
-            ],
         ]);
     }
 }


### PR DESCRIPTION
named placeholders can be used multiple times and therefore the count of placeholders/parameters is not relevant