### PR TITLE
added minimal `IntersectionType` support

### DIFF
--- a/src/QueryReflection/QuerySimulation.php
+++ b/src/QueryReflection/QuerySimulation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace staabm\PHPStanDba\QueryReflection;
 
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ConstantScalarType;
@@ -77,6 +78,19 @@ final class QuerySimulation
 
             // plain string types can contain anything.. we cannot reason about it
             return null;
+        }
+
+        if ($paramType instanceof IntersectionType) {
+            foreach ($paramType->getTypes() as $type) {
+                if ($type instanceof AccessoryType) {
+                    continue;
+                }
+
+                $simulated = self::simulateParamValueType($type, $preparedParam);
+                if (null !== $simulated) {
+                    return $simulated;
+                }
+            }
         }
 
         // all types which we can't simulate and render a query unresolvable at analysis time

--- a/tests/QuerySimulationTest.php
+++ b/tests/QuerySimulationTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace staabm\PHPStanDba\Tests;
+
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\TestCase;
+use staabm\PHPStanDba\QueryReflection\QuerySimulation;
+
+class QuerySimulationTest extends TestCase
+{
+    public function testIntersectionType()
+    {
+        $builder = ConstantArrayTypeBuilder::createEmpty();
+        $builder->setOffsetValueType(new IntegerType(), new IntegerType());
+
+        $simulatedValue = QuerySimulation::simulateParamValueType($builder->getArray(), false);
+        $this->assertNotNull($simulatedValue);
+    }
+}

--- a/tests/QuerySimulationTest.php
+++ b/tests/QuerySimulationTest.php
@@ -4,16 +4,28 @@ namespace staabm\PHPStanDba\Tests;
 
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\TestCase;
 use staabm\PHPStanDba\QueryReflection\QuerySimulation;
 
 class QuerySimulationTest extends TestCase
 {
-    public function testIntersectionType()
+    public function testIntersectionTypeInt()
     {
+        // non-empty-array<int, int>
         $builder = ConstantArrayTypeBuilder::createEmpty();
         $builder->setOffsetValueType(new IntegerType(), new IntegerType());
+
+        $simulatedValue = QuerySimulation::simulateParamValueType($builder->getArray(), false);
+        $this->assertNotNull($simulatedValue);
+    }
+
+    public function testIntersectionTypeString()
+    {
+        // non-empty-array<string, int>
+        $builder = ConstantArrayTypeBuilder::createEmpty();
+        $builder->setOffsetValueType(new StringType(), new IntegerType());
 
         $simulatedValue = QuerySimulation::simulateParamValueType($builder->getArray(), false);
         $this->assertNotNull($simulatedValue);

--- a/tests/QuerySimulationTest.php
+++ b/tests/QuerySimulationTest.php
@@ -6,7 +6,6 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
-use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\TestCase;
 use staabm\PHPStanDba\QueryReflection\QuerySimulation;
 

--- a/tests/QuerySimulationTest.php
+++ b/tests/QuerySimulationTest.php
@@ -3,6 +3,7 @@
 namespace staabm\PHPStanDba\Tests;
 
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\VerbosityLevel;
@@ -26,6 +27,17 @@ class QuerySimulationTest extends TestCase
         // non-empty-array<string, int>
         $builder = ConstantArrayTypeBuilder::createEmpty();
         $builder->setOffsetValueType(new StringType(), new IntegerType());
+
+        $simulatedValue = QuerySimulation::simulateParamValueType($builder->getArray(), false);
+        $this->assertNotNull($simulatedValue);
+    }
+
+    public function testIntersectionTypeMix()
+    {
+        // non-empty-array<string, int>
+        $builder = ConstantArrayTypeBuilder::createEmpty();
+        $builder->setOffsetValueType(new StringType(), new IntegerType());
+        $builder->setOffsetValueType(new IntegerType(), new FloatType());
 
         $simulatedValue = QuerySimulation::simulateParamValueType($builder->getArray(), false);
         $this->assertNotNull($simulatedValue);


### PR DESCRIPTION
should fix 
```
Unresolvable Query: Cannot simulate parameter value for type:  
         non-empty-array<int, int>. 
```
error

closes https://github.com/staabm/phpstan-dba/issues/176#issuecomment-1028318555