### PR TITLE
support `PDO::FETCH_COLUMN` in `fetchAll()`

### DIFF
--- a/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoQueryDynamicReturnTypeExtension.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -81,6 +82,10 @@ final class PdoQueryDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 
             $reflectionFetchType = $pdoStatementReflection->getFetchType($fetchModeType);
             if (null === $reflectionFetchType) {
+                return null;
+            }
+            // not yet implemented on query()
+            if (QueryReflector::FETCH_TYPE_COLUMN === $reflectionFetchType) {
                 return null;
             }
         }

--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
@@ -19,6 +20,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
 
 final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -76,7 +78,23 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
             }
         }
 
-        $rowType = $pdoStatementReflection->getRowType($statementType, $fetchType);
+        if (QueryReflector::FETCH_TYPE_COLUMN === $fetchType) {
+            $columnIndex = 0;
+
+            if (\count($args) > 1) {
+                $columnIndexType = $scope->getType($args[1]->value);
+                if ($columnIndexType instanceof ConstantIntegerType) {
+                    $columnIndex = $columnIndexType->getValue();
+                } else {
+                    return null;
+                }
+            }
+
+            $rowType = $pdoStatementReflection->getColumnRowType($statementType, $columnIndex);
+        } else {
+            $rowType = $pdoStatementReflection->getRowType($statementType, $fetchType);
+        }
+
         if (null === $rowType) {
             return null;
         }

--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -78,7 +78,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
             }
         }
 
-        if (QueryReflector::FETCH_TYPE_COLUMN === $fetchType) {
+        if ('fetchAll' === $methodReflection->getName() && QueryReflector::FETCH_TYPE_COLUMN === $fetchType) {
             $columnIndex = 0;
 
             if (\count($args) > 1) {

--- a/src/PdoReflection/PdoStatementReflection.php
+++ b/src/PdoReflection/PdoStatementReflection.php
@@ -64,6 +64,8 @@ final class PdoStatementReflection
             return QueryReflector::FETCH_TYPE_NUMERIC;
         } elseif (PDO::FETCH_BOTH === $fetchModeType->getValue()) {
             return QueryReflector::FETCH_TYPE_BOTH;
+        } elseif (PDO::FETCH_COLUMN === $fetchModeType->getValue()) {
+            return QueryReflector::FETCH_TYPE_COLUMN;
         }
 
         return null;
@@ -127,6 +129,20 @@ final class PdoStatementReflection
             $bothType = $genericTypes[1];
 
             return $this->reduceStatementResultType($bothType, $fetchType);
+        }
+
+        return null;
+    }
+
+    public function getColumnRowType(Type $statementType, int $columnIndex): ?Type
+    {
+        $statementType = $this->getRowType($statementType, QueryReflector::FETCH_TYPE_NUMERIC);
+
+        if ($statementType instanceof ConstantArrayType) {
+            $valueTypes = $statementType->getValueTypes();
+            if (\array_key_exists($columnIndex, $valueTypes)) {
+                return $valueTypes[$columnIndex];
+            }
         }
 
         return null;

--- a/src/QueryReflection/QueryReflector.php
+++ b/src/QueryReflection/QueryReflector.php
@@ -14,6 +14,8 @@ interface QueryReflector
     public const FETCH_TYPE_BOTH = 5;
     public const FETCH_TYPE_KEY_VALUE = 6;
 
+    public const FETCH_TYPE_COLUMN = 50;
+
     public function validateQueryString(string $queryString): ?Error;
 
     /**

--- a/tests/default/data/pdo-stmt-fetch.php
+++ b/tests/default/data/pdo-stmt-fetch.php
@@ -28,6 +28,15 @@ class Foo
         $all = $stmt->fetchAll(PDO::FETCH_ASSOC);
         assertType('array<int, array{email: string, adaid: int<0, 4294967295>}>', $all);
 
+        $all = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        assertType('array<int, string>', $all);
+
+        $all = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+        assertType('array<int, string>', $all);
+
+        $all = $stmt->fetchAll(PDO::FETCH_COLUMN, 1);
+        assertType('array<int, int<0, 4294967295>>', $all);
+
         // not yet supported fetch types
         $all = $stmt->fetchAll(PDO::FETCH_OBJ);
         assertType('array', $all); // XXX since php8 this cannot return false

--- a/tests/rules/config/.phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpstan-dba-mysqli.cache
@@ -972,7 +972,7 @@
     array (
       'result' => 
       array (
-        5 => NULL,
+        3 => NULL,
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE gesperrt=1' => 

--- a/tests/rules/config/.phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpstan-dba-mysqli.cache
@@ -972,7 +972,7 @@
     array (
       'result' => 
       array (
-        3 => NULL,
+        5 => NULL,
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE gesperrt=1' => 

--- a/tests/rules/config/.phpstan-dba-pdo.cache
+++ b/tests/rules/config/.phpstan-dba-pdo.cache
@@ -972,7 +972,7 @@
     array (
       'result' => 
       array (
-        3 => NULL,
+        5 => NULL,
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE gesperrt=1' => 


### PR DESCRIPTION
refs https://github.com/staabm/phpstan-dba/issues/269

it seems `PDO::FETCH_COLUMN` is not supported on `fetch()`.
its supported on `PDO->query()` though, but we might tackle this later