### PR TITLE
PDO: support `PDO::FETCH_COLUMN` in `fetch()`

### DIFF
--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -78,7 +78,7 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
             }
         }
 
-        if ('fetchAll' === $methodReflection->getName() && QueryReflector::FETCH_TYPE_COLUMN === $fetchType) {
+        if (QueryReflector::FETCH_TYPE_COLUMN === $fetchType) {
             $columnIndex = 0;
 
             if (\count($args) > 1) {

--- a/tests/default/data/pdo-stmt-fetch.php
+++ b/tests/default/data/pdo-stmt-fetch.php
@@ -63,6 +63,16 @@ class Foo
         $all = $stmt->fetch(PDO::FETCH_ASSOC);
         assertType('array{email: string, adaid: int<0, 4294967295>}|false', $all);
 
+        $all = $stmt->fetch(PDO::FETCH_COLUMN);
+        assertType('string|false', $all);
+
+        $all = $stmt->fetch(PDO::FETCH_COLUMN, 0);
+        assertType('string|false', $all);
+
+        $all = $stmt->fetch(PDO::FETCH_COLUMN, 1);
+        assertType( 'int<0, 4294967295>|false', $all);
+
+
         // not yet supported fetch types
         $all = $stmt->fetch(PDO::FETCH_OBJ);
         assertType('mixed', $all);

--- a/tests/default/data/pdo-stmt-fetch.php
+++ b/tests/default/data/pdo-stmt-fetch.php
@@ -70,8 +70,7 @@ class Foo
         assertType('string|false', $all);
 
         $all = $stmt->fetch(PDO::FETCH_COLUMN, 1);
-        assertType( 'int<0, 4294967295>|false', $all);
-
+        assertType('int<0, 4294967295>|false', $all);
 
         // not yet supported fetch types
         $all = $stmt->fetch(PDO::FETCH_OBJ);

--- a/tests/rules/config/.phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpstan-dba-mysqli.cache
@@ -972,7 +972,7 @@
     array (
       'result' => 
       array (
-        5 => NULL,
+        3 => NULL,
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE gesperrt=1' => 


### PR DESCRIPTION
refs https://github.com/staabm/phpstan-dba/issues/269

@xPaw could you double check the types are what to expect?
initially I had the feeling this would not be supported, as I was not able to find it in the php.net manual