### PR TITLE
Stabilize error/result in cache

### DIFF
--- a/src/QueryReflection/ReflectionCache.php
+++ b/src/QueryReflection/ReflectionCache.php
@@ -148,9 +148,11 @@ final class ReflectionCache
             // sort records to prevent unnecessary cache invalidation caused by different order of queries
             ksort($newRecords);
 
-            foreach ($newRecords as $newRecord) {
+            foreach ($newRecords as &$newRecord) {
                 ksort($newRecord);
             }
+
+            unset($newRecord);
 
             $cacheContent = '<?php return '.var_export([
                     'schemaVersion' => self::SCHEMA_VERSION,

--- a/src/QueryReflection/ReflectionCache.php
+++ b/src/QueryReflection/ReflectionCache.php
@@ -146,9 +146,11 @@ final class ReflectionCache
             }
 
             // sort records to prevent unnecessary cache invalidation caused by different order of queries
-            uksort($newRecords, function ($queryA, $queryB) {
-                return $queryA <=> $queryB;
-            });
+            ksort($newRecords);
+
+            foreach ($newRecords as $newRecord) {
+                ksort($newRecord);
+            }
 
             $cacheContent = '<?php return '.var_export([
                     'schemaVersion' => self::SCHEMA_VERSION,


### PR DESCRIPTION
Fixes #298

I think there's a different type of cache order issue with `__set_state` which I suspect comes from using newer PHP version (I run php 8.1). All my caches are updated with `keyType` and `itemType` moves above `allArrays`, not really sure what's up with that.

I think `var_export` logic changed in what order it dumps properties?
EDIT: Yep, looks like it changed in PHP 8.1 - https://3v4l.org/Zt4tA