### PR TITLE
`fetchAll(PDO::FETCH_KEY_PAIR)` has incorrect return type with an extra array

### DIFF
--- a/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/PdoStatementFetchDynamicReturnTypeExtension.php
@@ -127,6 +127,9 @@ final class PdoStatementFetchDynamicReturnTypeExtension implements DynamicMethod
         }
 
         if ('fetchAll' === $methodReflection->getName()) {
+            if (QueryReflector::FETCH_TYPE_KEY_VALUE === $fetchType) {
+                return $rowType;
+            }
             return new ArrayType(new IntegerType(), $rowType);
         }
 

--- a/tests/default/data/pdo-stmt-fetch.php
+++ b/tests/default/data/pdo-stmt-fetch.php
@@ -39,7 +39,7 @@ class Foo
         assertType('array<int, int<0, 4294967295>>', $all);
 
         $all = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
-        assertType('array<int, array<string, int<0, 4294967295>>>', $all);
+        assertType('array<string, int<0, 4294967295>>', $all);
 
         $all = $stmt->fetchAll(PDO::FETCH_CLASS, MyRowClass::class);
         assertType('array<int, staabm\PHPStanDba\Tests\Fixture\MyRowClass>', $all);


### PR DESCRIPTION
Closes https://github.com/staabm/phpstan-dba/issues/305