### PR TITLE
Use transactions when simulating queries

### DIFF
--- a/src/QueryReflection/MysqliQueryReflector.php
+++ b/src/QueryReflection/MysqliQueryReflector.php
@@ -131,6 +131,8 @@ final class MysqliQueryReflector implements QueryReflector
             return $this->cache[$queryString] = null;
         }
 
+        $this->db->begin_transaction(\MYSQLI_TRANS_START_READ_ONLY);
+
         try {
             $result = $this->db->query($simulatedQuery);
 
@@ -144,6 +146,8 @@ final class MysqliQueryReflector implements QueryReflector
             return $this->cache[$queryString] = $resultInfo;
         } catch (mysqli_sql_exception $e) {
             return $this->cache[$queryString] = $e;
+        } finally {
+            $this->db->rollback();
         }
     }
 }

--- a/src/QueryReflection/PdoQueryReflector.php
+++ b/src/QueryReflection/PdoQueryReflector.php
@@ -140,9 +140,21 @@ final class PdoQueryReflector implements QueryReflector
         }
 
         try {
+            $this->pdo->beginTransaction();
+        } catch (PDOException $e) {
+            // not all drivers may support transactions
+        }
+
+        try {
             $stmt = $this->pdo->query($simulatedQuery);
         } catch (PDOException $e) {
             return $this->cache[$queryString] = $e;
+        } finally {
+            try {
+                $this->pdo->rollBack();
+            } catch (PDOException $e) {
+                // not all drivers may support transactions
+            }
         }
 
         $this->cache[$queryString] = [];


### PR DESCRIPTION
While the code already checks for `SELECT` statements only, this should enforce it on the database level.

For mysqli driver, it will throw "Cannot execute statement in a READ ONLY transaction" error, while in PDO in worse case it will roll back any of the changed data.
