### PR TITLE
added failling PdoStatementObjectType test

### DIFF
--- a/tests/default/data/pdo-stmt-obj-type.php
+++ b/tests/default/data/pdo-stmt-obj-type.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PdoStmtObjectTypeTest;
+
+use PDO;
+use PDOStatement;
+use function PHPStan\Testing\assertType;
+use staabm\PHPStanDba\Tests\Fixture\MyRowClass;
+
+class Foo
+{
+    /**
+     * @return PDOStatement<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}>
+     */
+    private function prepare(PDO $pdo): PDOStatement {
+        return $pdo->prepare('SELECT email, adaid FROM ada');
+    }
+
+    public function fetch(PDO $pdo)
+    {
+        $stmt = $this->prepare($pdo);
+        $stmt->execute();
+
+        assertType('PDOStatement<array{email: string, 0: string, adaid: int<0, 4294967295>, 1: int<0, 4294967295>}>', $stmt);
+
+        $all = $stmt->fetch(PDO::FETCH_NUM);
+        assertType('array{string, int<0, 4294967295>}|false', $all);
+
+        $all = $stmt->fetch(PDO::FETCH_ASSOC);
+        assertType('array{email: string, adaid: int<0, 4294967295>}|false', $all);
+
+        $all = $stmt->fetch(PDO::FETCH_COLUMN);
+        assertType('string|false', $all);
+    }
+}


### PR DESCRIPTION
refs https://github.com/staabm/phpstan-dba/issues/282#issuecomment-1037036514

this should also make phpstan-dba analysis possible across method boundaries.
atm all parts required for the inference need to be accessible from a single method.

I guess cases like

```php
    public function querySelected(PDO $pdo): PDOStatement
    {
        return $pdo->query('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
    }

    public function fetch(PDO $pdo):array {
       $stmt = $this->querySelected($pdo);
       return $stmt->fetch();
    }

    public function workWithData(PDO $pdo) {
       $data = $this->fetch($pdo);
       assertType('string', $data['email']);
    }
```

should work after we use the `ObjectType` properly