### PR TITLE
fix build

### DIFF
--- a/.phpstan-dba-mysqli.cache
+++ b/.phpstan-dba-mysqli.cache
@@ -1,6 +1,6 @@
 <?php return array (
   'schemaVersion' => 'v6-schema-hash',
-  'schemaHash' => '02acd076c16216160aaacceb679ba82d',
+  'schemaHash' => 'ec5d0029b6ff5f80b8e6fcebaddf8fcc',
   'records' => 
   array (
     '
@@ -23,7 +23,6 @@
             GROUP BY
                 grouper' => 
     array (
-      'error' => NULL,
       'result' => 
       array (
         5 => 
@@ -58,6 +57,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -70,6 +70,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -92,6 +93,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -116,13 +118,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -154,6 +157,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -173,6 +177,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -189,214 +194,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
               PHPStan\Type\StringType::__set_state(array(
               )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
-      ),
-    ),
-    '
-            SELECT
-                MD5(
-                    GROUP_CONCAT(
-                        CONCAT(
-                            COALESCE(COLUMN_NAME, ""),
-                            COALESCE(EXTRA, ""),
-                            COLUMN_TYPE,
-                            IS_NULLABLE
-                        )
-                    )
-                ) AS dbsignature,
-                1 AS grouper
-            FROM
-                information_schema.columns
-            WHERE
-                table_schema = DATABASE()
-            GROUP BY
-                grouper' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            1 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            2 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
               1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
               PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
-        3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 0,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            1 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -478,6 +283,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -527,105 +333,11 @@
         5 => NULL,
       ),
     ),
-    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada' => 
+    'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
     array (
       'result' => 
       array (
-        3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 0,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
+        4 => NULL,
       ),
     ),
   ),

--- a/.phpstan-dba-pdo.cache
+++ b/.phpstan-dba-pdo.cache
@@ -57,6 +57,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -69,6 +70,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -91,6 +93,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -115,13 +118,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -153,6 +157,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -172,6 +177,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -188,214 +194,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
               PHPStan\Type\StringType::__set_state(array(
               )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
-      ),
-    ),
-    '
-            SELECT
-                MD5(
-                    GROUP_CONCAT(
-                        CONCAT(
-                            COALESCE(COLUMN_NAME, ""),
-                            COALESCE(EXTRA, ""),
-                            COLUMN_TYPE,
-                            IS_NULLABLE
-                        )
-                    )
-                ) AS dbsignature,
-                1 AS grouper
-            FROM
-                information_schema.columns
-            WHERE
-                table_schema = DATABASE()
-            GROUP BY
-                grouper' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            1 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            2 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
               1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
               PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
-        3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 0,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-            )),
-            1 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -477,127 +283,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'COLUMN_NAME',
-                 'isClassString' => false,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'COLUMN_TYPE',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'value' => 'EXTRA',
-                 'isClassString' => false,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
-          )),
-        )),
-      ),
-    ),
-    'SELECT
-                    coalesce(COLUMN_NAME, "") as COLUMN_NAME,
-                    coalesce(EXTRA, "") as EXTRA,
-                    COLUMN_TYPE
-                 FROM information_schema.columns
-                 WHERE table_name = ? AND table_schema = DATABASE()' => 
-    array (
-      'result' => 
-      array (
-        5 => NULL,
-      ),
-    ),
-    'SELECT
-                    coalesce(COLUMN_NAME, "") as COLUMN_NAME,
-                    coalesce(EXTRA, "") as EXTRA,
-                    COLUMN_TYPE
-                 FROM information_schema.columns
-                 WHERE table_name = \'1970-01-01\' AND table_schema = DATABASE()' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 3,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'COLUMN_NAME',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'EXTRA',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'value' => 'COLUMN_TYPE',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 

--- a/tests/default/config/.phpstan-dba-mysqli.cache
+++ b/tests/default/config/.phpstan-dba-mysqli.cache
@@ -358,6 +358,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -370,6 +371,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -388,6 +390,7 @@
             )),
             10 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -400,6 +403,7 @@
             )),
             11 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -412,6 +416,7 @@
             )),
             12 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -424,6 +429,7 @@
             )),
             13 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -436,6 +442,7 @@
             )),
             14 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -448,6 +455,7 @@
             )),
             15 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -460,6 +468,7 @@
             )),
             16 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -472,6 +481,7 @@
             )),
             17 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -484,6 +494,7 @@
             )),
             18 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -496,6 +507,7 @@
             )),
             19 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -508,6 +520,7 @@
             )),
             20 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -522,6 +535,7 @@
             )),
             21 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -536,6 +550,7 @@
             )),
             22 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -548,6 +563,7 @@
             )),
             23 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -560,6 +576,7 @@
             )),
             24 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -572,6 +589,7 @@
             )),
             25 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -584,6 +602,7 @@
             )),
             26 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -596,6 +615,7 @@
             )),
             27 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -608,6 +628,7 @@
             )),
             28 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -620,6 +641,7 @@
             )),
             29 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -644,6 +666,7 @@
             )),
             34 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -656,6 +679,7 @@
             )),
             35 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -814,6 +838,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1135,16 +1160,17 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1208,6 +1234,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1222,6 +1249,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1236,6 +1264,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1250,6 +1279,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1270,6 +1300,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1282,6 +1313,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1298,6 +1330,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1340,13 +1373,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1397,6 +1431,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1496,6 +1531,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1558,6 +1594,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1620,6 +1657,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1682,6 +1720,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1744,6 +1783,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1806,6 +1846,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1889,6 +1930,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1951,6 +1993,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2013,6 +2056,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2075,6 +2119,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2137,6 +2182,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2199,6 +2245,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2261,6 +2308,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2319,6 +2367,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2375,6 +2424,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2421,6 +2471,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2435,6 +2486,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2453,6 +2505,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2468,6 +2521,7 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
@@ -2520,6 +2574,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2635,6 +2690,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2659,15 +2715,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2708,6 +2765,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2724,15 +2782,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2795,6 +2854,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2819,15 +2879,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2890,6 +2951,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2914,15 +2976,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2985,6 +3048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3009,15 +3073,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3080,6 +3145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3104,15 +3170,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3175,6 +3242,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3199,15 +3267,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3270,6 +3339,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3294,15 +3364,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3365,6 +3436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3389,15 +3461,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3481,6 +3554,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3505,15 +3579,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3567,6 +3642,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3583,15 +3659,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3648,6 +3725,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3672,15 +3750,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3743,6 +3822,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3767,15 +3847,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3845,6 +3926,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3869,15 +3951,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3940,6 +4023,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3964,15 +4048,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4035,6 +4120,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4059,15 +4145,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4130,6 +4217,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4154,15 +4242,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4246,6 +4335,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4270,15 +4360,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4341,6 +4432,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4365,15 +4457,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4436,6 +4529,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4460,15 +4554,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4569,6 +4664,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4611,15 +4707,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4720,6 +4817,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4762,15 +4860,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4871,6 +4970,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4913,15 +5013,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5022,6 +5123,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5064,15 +5166,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5173,6 +5276,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5215,15 +5319,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5331,6 +5436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5373,15 +5479,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5482,6 +5589,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5524,15 +5632,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5633,6 +5742,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5675,15 +5785,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5784,6 +5895,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5826,15 +5938,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5935,6 +6048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5977,15 +6091,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6086,6 +6201,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6128,15 +6244,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/default/config/.phpstan-dba-pdo.cache
+++ b/tests/default/config/.phpstan-dba-pdo.cache
@@ -358,6 +358,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -370,6 +371,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -388,6 +390,7 @@
             )),
             10 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -400,6 +403,7 @@
             )),
             11 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -412,6 +416,7 @@
             )),
             12 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -424,6 +429,7 @@
             )),
             13 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -436,6 +442,7 @@
             )),
             14 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -448,6 +455,7 @@
             )),
             15 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -460,6 +468,7 @@
             )),
             16 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -472,6 +481,7 @@
             )),
             17 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -484,6 +494,7 @@
             )),
             18 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -496,6 +507,7 @@
             )),
             19 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -508,6 +520,7 @@
             )),
             20 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -522,6 +535,7 @@
             )),
             21 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -536,6 +550,7 @@
             )),
             22 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -548,6 +563,7 @@
             )),
             23 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -560,6 +576,7 @@
             )),
             24 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -572,6 +589,7 @@
             )),
             25 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -584,6 +602,7 @@
             )),
             26 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -596,6 +615,7 @@
             )),
             27 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -608,6 +628,7 @@
             )),
             28 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -620,6 +641,7 @@
             )),
             29 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -644,6 +666,7 @@
             )),
             34 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -656,6 +679,7 @@
             )),
             35 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -814,6 +838,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1135,16 +1160,17 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1208,6 +1234,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1222,6 +1249,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1236,6 +1264,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1250,6 +1279,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1270,6 +1300,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1282,6 +1313,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1298,6 +1330,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1340,13 +1373,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1397,6 +1431,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1496,6 +1531,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1558,6 +1594,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1620,6 +1657,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1682,6 +1720,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1744,6 +1783,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1806,6 +1846,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1889,6 +1930,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1951,6 +1993,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2013,6 +2056,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2075,6 +2119,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2137,6 +2182,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2199,6 +2245,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2261,6 +2308,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2319,6 +2367,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2375,6 +2424,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2421,6 +2471,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2435,6 +2486,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2453,6 +2505,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2468,6 +2521,7 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
@@ -2520,6 +2574,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2635,6 +2690,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2659,15 +2715,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2708,6 +2765,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2724,15 +2782,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2795,6 +2854,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2819,15 +2879,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2890,6 +2951,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2914,15 +2976,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2985,6 +3048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3009,15 +3073,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3080,6 +3145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3104,15 +3170,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3175,6 +3242,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3199,15 +3267,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3270,6 +3339,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3294,15 +3364,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3365,6 +3436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3389,15 +3461,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3481,6 +3554,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3505,15 +3579,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3567,6 +3642,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3583,15 +3659,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3648,6 +3725,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3672,15 +3750,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3743,6 +3822,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3767,15 +3847,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3845,6 +3926,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3869,15 +3951,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3940,6 +4023,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3964,15 +4048,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4035,6 +4120,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4059,15 +4145,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4130,6 +4217,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4154,15 +4242,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4246,6 +4335,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4270,15 +4360,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4341,6 +4432,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4365,15 +4457,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4436,6 +4529,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4460,15 +4554,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4569,6 +4664,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4611,15 +4707,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4720,6 +4817,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4762,15 +4860,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4871,6 +4970,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4913,15 +5013,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5022,6 +5123,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5064,15 +5166,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5173,6 +5276,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5215,15 +5319,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5331,6 +5436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5373,15 +5479,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5482,6 +5589,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5524,15 +5632,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5633,6 +5742,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5675,15 +5785,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5784,6 +5895,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5826,15 +5938,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5935,6 +6048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5977,15 +6091,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6086,6 +6201,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6128,15 +6244,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
@@ -358,6 +358,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -370,6 +371,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -388,6 +390,7 @@
             )),
             10 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -400,6 +403,7 @@
             )),
             11 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -412,6 +416,7 @@
             )),
             12 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -424,6 +429,7 @@
             )),
             13 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -436,6 +442,7 @@
             )),
             14 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -448,6 +455,7 @@
             )),
             15 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -460,6 +468,7 @@
             )),
             16 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -472,6 +481,7 @@
             )),
             17 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -484,6 +494,7 @@
             )),
             18 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -496,6 +507,7 @@
             )),
             19 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -508,6 +520,7 @@
             )),
             20 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -522,6 +535,7 @@
             )),
             21 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -536,6 +550,7 @@
             )),
             22 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -548,6 +563,7 @@
             )),
             23 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -560,6 +576,7 @@
             )),
             24 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -572,6 +589,7 @@
             )),
             25 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -584,6 +602,7 @@
             )),
             26 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -596,6 +615,7 @@
             )),
             27 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -608,6 +628,7 @@
             )),
             28 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -620,6 +641,7 @@
             )),
             29 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -644,6 +666,7 @@
             )),
             34 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -656,6 +679,7 @@
             )),
             35 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -814,6 +838,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1135,16 +1160,17 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1208,6 +1234,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1222,6 +1249,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1236,6 +1264,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1250,6 +1279,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1270,6 +1300,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1282,6 +1313,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1298,6 +1330,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1340,13 +1373,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1398,6 +1432,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1412,6 +1447,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1430,6 +1466,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1454,15 +1491,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1523,6 +1561,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1537,6 +1576,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1551,6 +1591,7 @@
             )),
             4 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1565,6 +1606,7 @@
             )),
             5 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1583,6 +1625,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1616,15 +1659,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1675,6 +1719,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1774,6 +1819,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1836,6 +1882,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1898,6 +1945,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1960,6 +2008,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2022,6 +2071,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2084,6 +2134,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2167,6 +2218,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2229,6 +2281,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2291,6 +2344,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2353,6 +2407,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2415,6 +2470,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2477,6 +2533,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2539,6 +2596,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2597,6 +2655,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2653,6 +2712,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2699,6 +2759,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -2713,6 +2774,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2731,6 +2793,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2746,6 +2809,7 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
@@ -2798,6 +2862,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2913,6 +2978,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2937,15 +3003,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2986,6 +3053,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3002,15 +3070,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3073,6 +3142,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3097,15 +3167,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3168,6 +3239,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3192,15 +3264,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3263,6 +3336,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3287,15 +3361,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3358,6 +3433,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3382,15 +3458,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3453,6 +3530,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3477,15 +3555,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3548,6 +3627,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3572,15 +3652,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3643,6 +3724,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3667,15 +3749,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3759,6 +3842,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3783,15 +3867,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3861,6 +3946,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3885,15 +3971,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3934,6 +4021,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3950,15 +4038,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4021,6 +4110,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4045,15 +4135,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4123,6 +4214,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4147,15 +4239,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4218,6 +4311,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4242,15 +4336,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4313,6 +4408,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4337,15 +4433,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4408,6 +4505,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4432,15 +4530,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4524,6 +4623,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4548,15 +4648,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4619,6 +4720,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4643,15 +4745,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4714,6 +4817,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4738,15 +4842,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4847,6 +4952,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4889,15 +4995,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4998,6 +5105,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5040,15 +5148,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5149,6 +5258,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5191,15 +5301,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5300,6 +5411,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5342,15 +5454,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5451,6 +5564,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5493,15 +5607,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5609,6 +5724,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5651,15 +5767,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5760,6 +5877,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5802,15 +5920,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5911,6 +6030,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5953,15 +6073,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6062,6 +6183,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6104,15 +6226,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6213,6 +6336,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6255,15 +6379,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6364,6 +6489,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6406,15 +6532,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/default/config/.phpunit-phpstan-dba-pdo.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-pdo.cache
@@ -358,6 +358,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -370,6 +371,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -388,6 +390,7 @@
             )),
             10 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -400,6 +403,7 @@
             )),
             11 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -412,6 +416,7 @@
             )),
             12 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -424,6 +429,7 @@
             )),
             13 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -436,6 +442,7 @@
             )),
             14 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -448,6 +455,7 @@
             )),
             15 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -460,6 +468,7 @@
             )),
             16 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -472,6 +481,7 @@
             )),
             17 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -484,6 +494,7 @@
             )),
             18 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -496,6 +507,7 @@
             )),
             19 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -508,6 +520,7 @@
             )),
             20 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -522,6 +535,7 @@
             )),
             21 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -536,6 +550,7 @@
             )),
             22 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -548,6 +563,7 @@
             )),
             23 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -560,6 +576,7 @@
             )),
             24 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -572,6 +589,7 @@
             )),
             25 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -584,6 +602,7 @@
             )),
             26 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -596,6 +615,7 @@
             )),
             27 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -608,6 +628,7 @@
             )),
             28 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -620,6 +641,7 @@
             )),
             29 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -644,6 +666,7 @@
             )),
             34 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -656,6 +679,7 @@
             )),
             35 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -814,6 +838,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1135,16 +1160,17 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\StringType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1208,6 +1234,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1222,6 +1249,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1236,6 +1264,7 @@
             )),
             2 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1250,6 +1279,7 @@
             )),
             3 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1270,6 +1300,7 @@
             )),
             6 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -1282,6 +1313,7 @@
             )),
             7 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -1298,6 +1330,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1340,13 +1373,14 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              PHPStan\Type\IntegerType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
               PHPStan\Type\NullType::__set_state(array(
@@ -1397,6 +1431,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1496,6 +1531,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1558,6 +1594,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1620,6 +1657,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1682,6 +1720,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1744,6 +1783,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1806,6 +1846,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1889,6 +1930,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1951,6 +1993,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2013,6 +2056,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2075,6 +2119,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2137,6 +2182,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2199,6 +2245,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2261,6 +2308,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2319,6 +2367,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2375,6 +2424,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2421,6 +2471,7 @@
           array (
             0 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -2435,6 +2486,7 @@
             )),
             1 => 
             PHPStan\Type\UnionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -2453,6 +2505,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2468,6 +2521,7 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
@@ -2520,6 +2574,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2635,6 +2690,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2659,15 +2715,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2708,6 +2765,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2724,15 +2782,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2795,6 +2854,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2819,15 +2879,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2890,6 +2951,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -2914,15 +2976,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -2985,6 +3048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3009,15 +3073,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3080,6 +3145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3104,15 +3170,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3175,6 +3242,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3199,15 +3267,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3270,6 +3339,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3294,15 +3364,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3365,6 +3436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3389,15 +3461,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3481,6 +3554,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3505,15 +3579,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3583,6 +3658,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3607,15 +3683,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3656,6 +3733,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3672,15 +3750,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3743,6 +3822,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3767,15 +3847,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3845,6 +3926,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3869,15 +3951,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -3940,6 +4023,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -3964,15 +4048,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4035,6 +4120,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4059,15 +4145,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4130,6 +4217,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4154,15 +4242,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4246,6 +4335,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4270,15 +4360,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4341,6 +4432,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4365,15 +4457,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4436,6 +4529,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4460,15 +4554,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4569,6 +4664,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4611,15 +4707,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4720,6 +4817,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4762,15 +4860,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -4871,6 +4970,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -4913,15 +5013,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5022,6 +5123,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5064,15 +5166,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5173,6 +5276,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5215,15 +5319,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5331,6 +5436,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5373,15 +5479,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5482,6 +5589,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5524,15 +5632,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5633,6 +5742,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5675,15 +5785,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5784,6 +5895,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5826,15 +5938,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -5935,6 +6048,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -5977,15 +6091,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -6086,6 +6201,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -6128,15 +6244,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchAssoc/config/.phpstan-dba-mysqli.cache
+++ b/tests/defaultFetchAssoc/config/.phpstan-dba-mysqli.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchAssoc/config/.phpstan-dba-pdo.cache
+++ b/tests/defaultFetchAssoc/config/.phpstan-dba-pdo.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchAssoc/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/defaultFetchAssoc/config/.phpunit-phpstan-dba-mysqli.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchAssoc/config/.phpunit-phpstan-dba-pdo.cache
+++ b/tests/defaultFetchAssoc/config/.phpunit-phpstan-dba-pdo.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchNumeric/config/.phpstan-dba-mysqli.cache
+++ b/tests/defaultFetchNumeric/config/.phpstan-dba-mysqli.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchNumeric/config/.phpstan-dba-pdo.cache
+++ b/tests/defaultFetchNumeric/config/.phpstan-dba-pdo.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchNumeric/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/defaultFetchNumeric/config/.phpunit-phpstan-dba-mysqli.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/defaultFetchNumeric/config/.phpunit-phpstan-dba-pdo.cache
+++ b/tests/defaultFetchNumeric/config/.phpunit-phpstan-dba-pdo.cache
@@ -59,6 +59,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -83,15 +84,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -192,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -234,15 +237,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/rules/SyntaxErrorInQueryFunctionRuleMysqliReflectorTest.php
+++ b/tests/rules/SyntaxErrorInQueryFunctionRuleMysqliReflectorTest.php
@@ -27,15 +27,15 @@ class SyntaxErrorInQueryFunctionRuleMysqliReflectorTest extends AbstractServiceA
         $this->analyse([__DIR__.'/data/syntax-error-in-query-function.php'], [
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
-                11,
+                9,
             ],
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
-                21,
+                19,
             ],
             [
                 "Query error: Unknown column 'asdsa' in 'where clause' (1054).",
-                41,
+                39,
             ],
         ]);
     }

--- a/tests/rules/SyntaxErrorInQueryFunctionRulePdoReflectorTest.php
+++ b/tests/rules/SyntaxErrorInQueryFunctionRulePdoReflectorTest.php
@@ -19,7 +19,7 @@ class SyntaxErrorInQueryFunctionRulePdoReflectorTest extends AbstractServiceAwar
     public function testSyntaxErrorInQueryRule(): void
     {
         if ('pdo' !== getenv('DBA_REFLECTOR')) {
-            $this->markTestSkipped('Only works with MysqliReflector');
+            $this->markTestSkipped('Only works with PdoQueryReflector');
         }
 
         require_once __DIR__.'/data/syntax-error-in-query-function.php';
@@ -27,15 +27,15 @@ class SyntaxErrorInQueryFunctionRulePdoReflectorTest extends AbstractServiceAwar
         $this->analyse([__DIR__.'/data/syntax-error-in-query-function.php'], [
             [
                 "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (42000).",
-                11,
+                9,
             ],
             [
                 "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (42000).",
-                21,
+                19,
             ],
             [
                 "Query error: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'asdsa' in 'where clause' (42S22).",
-                41,
+                39,
             ],
         ]);
     }

--- a/tests/rules/UnresolvableQueryFunctionRuleTest.php
+++ b/tests/rules/UnresolvableQueryFunctionRuleTest.php
@@ -35,12 +35,12 @@ class UnresolvableQueryFunctionRuleTest extends AbstractServiceAwareRuleTestCase
         $this->analyse([__DIR__.'/data/unresolvable-query-in-function.php'], [
             [
                 'Unresolvable Query: Cannot simulate parameter value for type: mixed.',
-                11,
+                9,
                 UnresolvableQueryException::RULE_TIP,
             ],
             [
                 'Unresolvable Query: Cannot simulate parameter value for type: mixed.',
-                17,
+                15,
                 UnresolvableQueryException::RULE_TIP,
             ],
         ]);

--- a/tests/rules/config/.phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpstan-dba-mysqli.cache
@@ -114,6 +114,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -193,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -291,6 +293,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -315,15 +318,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -428,6 +432,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -452,15 +457,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -485,93 +491,6 @@
     array (
       'result' => 
       array (
-        4 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
         3 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'allArrays' => NULL,
@@ -628,6 +547,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -654,15 +574,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -757,6 +678,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -799,15 +721,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -908,6 +831,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -950,15 +874,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1059,6 +984,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1101,15 +1027,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1210,6 +1137,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1252,15 +1180,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1390,6 +1319,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1432,15 +1362,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/rules/config/.phpstan-dba-pdo.cache
+++ b/tests/rules/config/.phpstan-dba-pdo.cache
@@ -114,6 +114,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -193,6 +194,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -291,6 +293,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -315,15 +318,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -428,6 +432,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -452,15 +457,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -485,93 +491,6 @@
     array (
       'result' => 
       array (
-        4 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-            ),
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-          )),
-        )),
         3 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'allArrays' => NULL,
@@ -628,6 +547,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -654,15 +574,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -757,6 +678,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -799,15 +721,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -908,6 +831,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -950,15 +874,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1059,6 +984,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1101,15 +1027,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1210,6 +1137,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1252,15 +1180,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),
@@ -1390,6 +1319,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 
@@ -1432,15 +1362,16 @@
           )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => false,
              'types' => 
             array (
               0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
               )),
             ),
           )),

--- a/tests/rules/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpunit-phpstan-dba-mysqli.cache
@@ -17,112 +17,6 @@
       )),
     ),
     '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-            FOR SHARE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET 1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\',  \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT   \'1\',     \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE NULL
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
             SELECT email adaid
             WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
             FROM ada
@@ -337,6 +231,10 @@
          'code' => 1054,
       )),
     ),
+    'SELECT email, adaid FROM ada WHERE email=\'my_other_table\' LIMIT 1' => 
+    array (
+      'error' => NULL,
+    ),
     'SELECT email, adaid FROM ada WHERE gesperrt = \'1\'' => 
     array (
       'error' => NULL,
@@ -350,11 +248,6 @@
       )),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada' => 
-    array (
-      'error' => NULL,
-    ),
-    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada
-            WHERE (gesperrt=\'1\' AND freigabe1u1=1) OR (gesperrt=\'1\' AND freigabe1u1=0)' => 
     array (
       'error' => NULL,
     ),

--- a/tests/rules/config/.phpunit-phpstan-dba-pdo.cache
+++ b/tests/rules/config/.phpunit-phpstan-dba-pdo.cache
@@ -17,112 +17,6 @@
       )),
     ),
     '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-            FOR SHARE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET \'1\'
-            FOR UPDATE
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\'
-            OFFSET 1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT        \'1\',  \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\'
-            LIMIT   \'1\',     \'1\'
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example%\'
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
-            SELECT email, adaid
-            FROM ada
-            WHERE gesperrt = \'1\' AND email LIKE NULL
-            LIMIT        1
-        ' => 
-    array (
-      'error' => NULL,
-    ),
-    '
             SELECT email adaid
             WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
             FROM ada
@@ -337,6 +231,10 @@
          'code' => '42S22',
       )),
     ),
+    'SELECT email, adaid FROM ada WHERE email=\'my_other_table\' LIMIT 1' => 
+    array (
+      'error' => NULL,
+    ),
     'SELECT email, adaid FROM ada WHERE gesperrt = \'1\'' => 
     array (
       'error' => NULL,
@@ -350,11 +248,6 @@
       )),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada' => 
-    array (
-      'error' => NULL,
-    ),
-    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada
-            WHERE (gesperrt=\'1\' AND freigabe1u1=1) OR (gesperrt=\'1\' AND freigabe1u1=0)' => 
     array (
       'error' => NULL,
     ),

--- a/tests/rules/data/syntax-error-in-query-function.php
+++ b/tests/rules/data/syntax-error-in-query-function.php
@@ -2,18 +2,16 @@
 
 namespace SyntaxErrorInQueryFunctionRuleTest;
 
-use Deployer\DbCredentials;
-
 class Foo
 {
-    public function syntaxError(DbCredentials $dbCredentials)
+    public function syntaxError(\mysqli $mysqli)
     {
-        \Deployer\runMysqlQuery('SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada', $dbCredentials);
+        mysqli_query($mysqli, 'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada');
     }
 
-    public function validQuery(DbCredentials $dbCredentials)
+    public function validQuery(\mysqli $mysqli)
     {
-        \Deployer\runMysqlQuery('SELECT email, adaid, gesperrt, freigabe1u1 FROM ada', $dbCredentials);
+        mysqli_query($mysqli, 'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada');
     }
 
     public function mysqliSyntaxError(\mysqli $mysqli)

--- a/tests/rules/data/unresolvable-query-in-function.php
+++ b/tests/rules/data/unresolvable-query-in-function.php
@@ -2,30 +2,28 @@
 
 namespace UnresolvableQueryInFunctionTest;
 
-use Deployer\DbCredentials;
-
 class Foo
 {
-    public function mixedParam(DbCredentials $dbCredentials, $mixed)
+    public function mixedParam(\mysqli $mysqli, $mixed)
     {
-        \Deployer\runMysqlQuery('SELECT adaid FROM ada WHERE gesperrt='.$mixed, $dbCredentials);
+        mysqli_query($mysqli, 'SELECT adaid FROM ada WHERE gesperrt='.$mixed);
     }
 
-    public function mixedParam2(DbCredentials $dbCredentials, $mixed)
+    public function mixedParam2(\mysqli $mysqli, $mixed)
     {
         $query = 'SELECT adaid FROM ada WHERE gesperrt='.$mixed;
-        \Deployer\runMysqlQuery($query, $dbCredentials);
+        mysqli_query($mysqli, $query);
     }
 
-    public function noErrorOnMixedQuery(DbCredentials $dbCredentials, $mixed)
+    public function noErrorOnMixedQuery(\mysqli $mysqli, $mixed)
     {
         // we should not report a error here, as this is like a call somewhere in between software layers
         // which don't know anything about the actual query
-        \Deployer\runMysqlQuery($mixed, $dbCredentials);
+        mysqli_query($mysqli, $mixed);
     }
 
-    public function noErrorOnStringQuery(DbCredentials $dbCredentials, string $query)
+    public function noErrorOnStringQuery(\mysqli $mysqli, string $query)
     {
-        \Deployer\runMysqlQuery($query, $dbCredentials);
+        mysqli_query($mysqli, $query);
     }
 }

--- a/tests/stringify/config/.phpstan-dba-mysqli.cache
+++ b/tests/stringify/config/.phpstan-dba-mysqli.cache
@@ -63,6 +63,7 @@
             )),
             2 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -75,6 +76,7 @@
             )),
             3 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -87,6 +89,7 @@
             )),
             4 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -99,6 +102,7 @@
             )),
             5 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -111,6 +115,7 @@
             )),
             6 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -123,6 +128,7 @@
             )),
             7 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -139,6 +145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 

--- a/tests/stringify/config/.phpstan-dba-pdo.cache
+++ b/tests/stringify/config/.phpstan-dba-pdo.cache
@@ -63,6 +63,7 @@
             )),
             2 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -75,6 +76,7 @@
             )),
             3 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -87,6 +89,7 @@
             )),
             4 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -99,6 +102,7 @@
             )),
             5 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -111,6 +115,7 @@
             )),
             6 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -123,6 +128,7 @@
             )),
             7 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -139,6 +145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 

--- a/tests/stringify/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/stringify/config/.phpunit-phpstan-dba-mysqli.cache
@@ -63,6 +63,7 @@
             )),
             2 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -75,6 +76,7 @@
             )),
             3 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -87,6 +89,7 @@
             )),
             4 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -99,6 +102,7 @@
             )),
             5 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -111,6 +115,7 @@
             )),
             6 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -123,6 +128,7 @@
             )),
             7 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -139,6 +145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 

--- a/tests/stringify/config/.phpunit-phpstan-dba-pdo.cache
+++ b/tests/stringify/config/.phpunit-phpstan-dba-pdo.cache
@@ -63,6 +63,7 @@
             )),
             2 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -75,6 +76,7 @@
             )),
             3 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -87,6 +89,7 @@
             )),
             4 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -99,6 +102,7 @@
             )),
             5 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -111,6 +115,7 @@
             )),
             6 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => true,
                'types' => 
               array (
                 0 => 
@@ -123,6 +128,7 @@
             )),
             7 => 
             PHPStan\Type\IntersectionType::__set_state(array(
+               'sortedTypes' => false,
                'types' => 
               array (
                 0 => 
@@ -139,6 +145,7 @@
           ),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'sortedTypes' => true,
              'types' => 
             array (
               0 => 


### PR DESCRIPTION
since phpstan switched to static reflection the testsuite needs a bit love

- don't depend on external function `\Deployer\runMysqlQuery` beeing present - simplied this bits to just use `mysqli`
- line errors have been adjusted to compensate removed `use` lines in the head of the tests - no functional changes
- fixed a few typos