### PR TITLE
moved mysql specific test into pdo-mysql

### DIFF
--- a/tests/default/data/pdo-mysql.php
+++ b/tests/default/data/pdo-mysql.php
@@ -27,4 +27,19 @@ class Foo
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{MAX(adaid): int<-32768, 32767>|null, MIN(adaid): int<-32768, 32767>|null, COUNT(adaid): int, AVG(adaid): float|null}>', $stmt);
     }
+
+    public function placeholderInData(PDO $pdo)
+    {
+        $query = 'SELECT adaid FROM ada WHERE email LIKE ":gesperrt%"';
+        $stmt = $pdo->prepare($query);
+        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
+        $stmt->execute();
+        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
+
+        $query = "SELECT adaid FROM ada WHERE email LIKE ':gesperrt%'";
+        $stmt = $pdo->prepare($query);
+        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
+        $stmt->execute();
+        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
+    }
 }

--- a/tests/default/data/pdo-mysql.php
+++ b/tests/default/data/pdo-mysql.php
@@ -30,12 +30,14 @@ class Foo
 
     public function placeholderInData(PDO $pdo)
     {
+        // double quotes within the query
         $query = 'SELECT adaid FROM ada WHERE email LIKE ":gesperrt%"';
         $stmt = $pdo->prepare($query);
         assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
         $stmt->execute();
         assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
 
+        // single quotes within the query
         $query = "SELECT adaid FROM ada WHERE email LIKE ':gesperrt%'";
         $stmt = $pdo->prepare($query);
         assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);

--- a/tests/default/data/pdo-prepare.php
+++ b/tests/default/data/pdo-prepare.php
@@ -60,18 +60,6 @@ class Foo
         assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
         $stmt->execute();
         assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
-
-        $query = 'SELECT adaid FROM ada WHERE email LIKE ":gesperrt%"';
-        $stmt = $pdo->prepare($query);
-        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
-        $stmt->execute();
-        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
-
-        $query = "SELECT adaid FROM ada WHERE email LIKE ':gesperrt%'";
-        $stmt = $pdo->prepare($query);
-        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
-        $stmt->execute();
-        assertType('PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>', $stmt);
     }
 
     public function arrayParam(PDO $pdo)


### PR DESCRIPTION
pgsql does not like these tests

```

1) staabm\PHPStanDba\Tests\DbaInferenceTest::testFileAsserts with data set "/home/runner/work/phpstan-dba/phpstan-dba/tests/default/data/pdo.php:158" ('type', '/home/runner/work/phpstan-dba...do.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\ObjectType Object (...), 158)
Expected type PDOStatement<array{adaid: int<-32768, 32767>}>, got type PDOStatement in /home/runner/work/phpstan-dba/phpstan-dba/tests/default/data/pdo.php on line 158.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'PDOStatement<array{adaid: int<-32768, 32767>}>'
+'PDOStatement'

phar:///home/runner/work/phpstan-dba/phpstan-dba/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:56
/home/runner/work/phpstan-dba/phpstan-dba/tests/default/DbaInferenceTest.php:77

2) staabm\PHPStanDba\Tests\DbaInferenceTest::testFileAsserts with data set "/home/runner/work/phpstan-dba/phpstan-dba/tests/default/data/pdo-prepare.php:66" ('type', '/home/runner/work/phpstan-dba...re.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\ObjectType Object (...), 66)
Expected type PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>, got type PDOStatement in /home/runner/work/phpstan-dba/phpstan-dba/tests/default/data/pdo-prepare.php on line 66.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'PDOStatement<array{adaid: int<-32768, 32767>, 0: int<-32768, 32767>}>'
+'PDOStatement'
```

since these are rather edge-cases we consider them supported only on mysql for now