### PR TITLE
Move ext-mysqli to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
 	"license": "MIT",
 	"require": {
 		"php": "^8.0",
-		"ext-mysqli": "*",
 		"composer-runtime-api": "^2.0",
 		"composer/semver": "^3.2",
 		"phpstan/phpstan": "^1.2"
 	},
 	"require-dev": {
+		"ext-mysqli": "*",
 		"ext-pdo": "*",
 		"doctrine/dbal": "^3.2",
 		"friendsofphp/php-cs-fixer": "3.4.0",


### PR DESCRIPTION
Unless there is a special need for mysqli extension to be present, could this be moved to require-dev? Right now, there is also PdoQueryReflector available, but you still have to install mysqli extension to use it.

```sh
$ composer require --dev staabm/phpstan-dba

In PackageDiscoveryTrait.php line 308:

Package staabm/phpstan-dba has requirements incompatible with your PHP version, PHP extensions and Composer version:
  - staabm/phpstan-dba 0.2.26 requires ext-mysqli * but it is not present.
```