### PR TITLE
don't analyse maybe existing data when QueryPlanAnalyzer::TABLES_WITHOUT_DATA

### DIFF
--- a/src/Analyzer/QueryPlanAnalyzerMysql.php
+++ b/src/Analyzer/QueryPlanAnalyzerMysql.php
@@ -77,7 +77,7 @@ final class QueryPlanAnalyzerMysql
         }
 
         foreach ($it as $row) {
-            // we cannot analyse tables without rows -> mysql will just return 'no matching row in const table'
+            // mysql might return 'no matching row in const table'
             if (null === $row['table']) {
                 continue;
             }
@@ -91,6 +91,11 @@ final class QueryPlanAnalyzerMysql
 
                 $result->addRow($row['table'], QueryPlanResult::NO_INDEX);
             } else {
+                // don't analyse maybe existing data, to make the result consistent with empty db schemas
+                if ($allowedRowsNotRequiringIndex === QueryPlanAnalyzer::TABLES_WITHOUT_DATA) {
+                    continue;
+                }
+
                 if (null !== $row['type'] && 'all' === strtolower($row['type']) && $row['rows'] >= $allowedRowsNotRequiringIndex) {
                     $result->addRow($row['table'], QueryPlanResult::TABLE_SCAN);
                 } elseif (true === $allowedUnindexedReads && $row['rows'] >= QueryPlanAnalyzer::DEFAULT_UNINDEXED_READS_THRESHOLD) {


### PR DESCRIPTION
makes sure we get a consistent result between different environments, where some contain table data and others don't.