### PR TITLE
enable bleedingEdge

### DIFF
--- a/config/extensions.neon
+++ b/config/extensions.neon
@@ -1,3 +1,6 @@
+includes:
+	- ../vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
 services:
     -
         class: staabm\PHPStanDba\Extensions\DoctrineConnectionQueryDynamicReturnTypeExtension
@@ -54,7 +57,7 @@ services:
         tags:
         	- phpstan.typeSpecifier.methodTypeSpecifyingExtension
 
-    -     
+    -
         class: staabm\PHPStanDba\Extensions\PdoStatementFetchObjectDynamicReturnTypeExtension
         tags:
         	- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/config/extensions.neon
+++ b/config/extensions.neon
@@ -1,5 +1,5 @@
 includes:
-	- ../vendor/phpstan/phpstan/conf/bleedingEdge.neon
+	- %currentWorkingDirectory%/conf/bleedingEdge.neon
 
 services:
     -


### PR DESCRIPTION
this PR just illustrates the problem of a phpunit error

```
The data provider specified for staabm\PHPStanDba\Tests\DbaInferenceTest::testFileAsserts is invalid.
_PHPStan_0b5253d36\Nette\FileNotFoundException: File 'phar://phpstan.phar/conf/bleedingEdge.neon' is missing or is not readable.
```

which happens when enabling bleeding edge, as described in the [blog post](https://phpstan.org/blog/what-is-bleeding-edge).. not sure yet what the problem is.

[upstream issue](https://github.com/phpstan/phpstan/discussions/7436)