### PR TITLE
prevent race conditions while writing cache file

### DIFF
--- a/src/QueryReflection/ReflectionCache.php
+++ b/src/QueryReflection/ReflectionCache.php
@@ -127,7 +127,7 @@ final class ReflectionCache
     private function readCachedRecords(bool $useReadLock): ?array
     {
         if (!is_file($this->cacheFile)) {
-            if (false === file_put_contents($this->cacheFile, '')) {
+            if (false === file_put_contents($this->cacheFile, '', LOCK_EX)) {
                 throw new DbaException(sprintf('Cache file "%s" is not readable and creating a new one did not succeed.', $this->cacheFile));
             }
         }
@@ -202,7 +202,7 @@ final class ReflectionCache
                     'runtimeConfig' => QueryReflection::getRuntimeConfiguration()->toArray(),
                 ], true).';';
 
-            if (false === file_put_contents($this->cacheFile, $cacheContent)) {
+            if (false === file_put_contents($this->cacheFile, $cacheContent, LOCK_EX)) {
                 throw new DbaException(sprintf('Unable to write cache file "%s"', $this->cacheFile));
             }
 


### PR DESCRIPTION
should prevent inconsistent files when writing cache like

![grafik](https://user-images.githubusercontent.com/120441/172871992-cbca0300-84bb-4292-b214-28a0f96bed77.png)

which turns into `Internal error: Internal error: syntax error, unexpected token "<", expecting end of file in file` errors