### PR TITLE
added `mysqli::execute_query()` support (php 8.2+ only)

### DIFF
--- a/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
+++ b/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
@@ -231,5 +231,4 @@ LINE 1: SELECT email, adaid FROM ada GROUP BY xy LIMIT 0
             ],
         ]);
     }
-    
 }

--- a/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
+++ b/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
@@ -217,4 +217,19 @@ LINE 1: SELECT email, adaid FROM ada GROUP BY xy LIMIT 0
 
         $this->analyse([__DIR__.'/data/syntax-error-in-query-method.php'], $expected);
     }
+
+    public function testMysqliExecuteQuery(): void
+    {
+        if (\PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('Test requires PHP 8.2.');
+        }
+
+        $this->analyse([__DIR__.'/data/mysqli_execute_query.php'], [
+            [
+                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
+                9,
+            ],
+        ]);
+    }
+    
 }


### PR DESCRIPTION
missing part of https://github.com/staabm/phpstan-dba/pull/425

depends on https://github.com/phpstan/phpstan/issues/8058

atm the test fails because the rule involved runs into this early exit

https://github.com/staabm/phpstan-dba/blob/f60f559183d22df4394f943d7a6a2470e6941fe2/src/Rules/SyntaxErrorInQueryMethodRule.php#L47-L50