### PR TITLE
support non-conditional `@psalm-taint-escape sql`

### DIFF
--- a/src/PhpDoc/PhpDocUtil.php
+++ b/src/PhpDoc/PhpDocUtil.php
@@ -38,8 +38,8 @@ final class PhpDocUtil
 
     /**
      * @param CallLike|MethodReflection $callLike
-     *@api
      *
+     *@api
      */
     public static function commentContains(string $text, $callLike, Scope $scope): bool
     {

--- a/src/PhpDoc/PhpDocUtil.php
+++ b/src/PhpDoc/PhpDocUtil.php
@@ -24,6 +24,8 @@ final class PhpDocUtil
             $methodReflection = $callLike;
         }
 
+        // XXX does not yet support conditional escaping
+        // https://psalm.dev/docs/security_analysis/avoiding_false_positives/#conditional-escaping-tainted-input
         if (null !== $methodReflection) {
             // atm no resolved phpdoc for methods
             // see https://github.com/phpstan/phpstan/discussions/7657

--- a/src/PhpDoc/PhpDocUtil.php
+++ b/src/PhpDoc/PhpDocUtil.php
@@ -13,10 +13,41 @@ final class PhpDocUtil
 {
     /**
      * @api
+     *
+     * @param CallLike|MethodReflection $callLike
      */
-    public static function commentContains(string $text, CallLike $callike, Scope $scope): bool
+    public static function matchTaintEscape($callLike, Scope $scope): ?string
     {
-        $methodReflection = self::getMethodReflection($callike, $scope);
+        if ($callLike instanceof CallLike) {
+            $methodReflection = self::getMethodReflection($callLike, $scope);
+        } else {
+            $methodReflection = $callLike;
+        }
+
+        if (null !== $methodReflection) {
+            // atm no resolved phpdoc for methods
+            // see https://github.com/phpstan/phpstan/discussions/7657
+            $phpDocString = $methodReflection->getDocComment();
+            if (null !== $phpDocString && preg_match('/@psalm-taint-escape\s+(\S+)$/m', $phpDocString, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param CallLike|MethodReflection $callLike
+     *@api
+     *
+     */
+    public static function commentContains(string $text, $callLike, Scope $scope): bool
+    {
+        if ($callLike instanceof CallLike) {
+            $methodReflection = self::getMethodReflection($callLike, $scope);
+        } else {
+            $methodReflection = $callLike;
+        }
 
         if (null !== $methodReflection) {
             // atm no resolved phpdoc for methods
@@ -35,9 +66,9 @@ final class PhpDocUtil
      *
      * @param string $annotation e.g. '@phpstandba-inference-placeholder'
      */
-    public static function matchStringAnnotation(string $annotation, CallLike $callike, Scope $scope): ?string
+    public static function matchStringAnnotation(string $annotation, CallLike $callLike, Scope $scope): ?string
     {
-        $methodReflection = self::getMethodReflection($callike, $scope);
+        $methodReflection = self::getMethodReflection($callLike, $scope);
 
         if (null !== $methodReflection) {
             // atm no resolved phpdoc for methods
@@ -57,21 +88,21 @@ final class PhpDocUtil
         return null;
     }
 
-    private static function getMethodReflection(CallLike $callike, Scope $scope): ?MethodReflection
+    private static function getMethodReflection(CallLike $callLike, Scope $scope): ?MethodReflection
     {
         $methodReflection = null;
-        if ($callike instanceof Expr\StaticCall) {
-            if ($callike->class instanceof Name && $callike->name instanceof Identifier) {
-                $classType = $scope->resolveTypeByName($callike->class);
-                $methodReflection = $scope->getMethodReflection($classType, $callike->name->name);
+        if ($callLike instanceof Expr\StaticCall) {
+            if ($callLike->class instanceof Name && $callLike->name instanceof Identifier) {
+                $classType = $scope->resolveTypeByName($callLike->class);
+                $methodReflection = $scope->getMethodReflection($classType, $callLike->name->name);
             }
-        } elseif ($callike instanceof Expr\MethodCall && $callike->name instanceof Identifier) {
+        } elseif ($callLike instanceof Expr\MethodCall && $callLike->name instanceof Identifier) {
             $classReflection = $scope->getClassReflection();
-            if (null !== $classReflection && $classReflection->hasMethod($callike->name->name)) {
-                $methodReflection = $classReflection->getMethod($callike->name->name, $scope);
+            if (null !== $classReflection && $classReflection->hasMethod($callLike->name->name)) {
+                $methodReflection = $classReflection->getMethod($callLike->name->name, $scope);
             } else {
-                $callerType = $scope->getType($callike->var);
-                $methodReflection = $scope->getMethodReflection($callerType, $callike->name->name);
+                $callerType = $scope->getType($callLike->var);
+                $methodReflection = $scope->getMethodReflection($callerType, $callLike->name->name);
             }
         }
 

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -201,7 +201,7 @@ final class QueryReflection
         }
 
         if ($queryExpr instanceof Expr\CallLike) {
-            if (PhpDocUtil::matchTaintEscape($queryExpr, $scope) === 'sql') {
+            if ('sql' === PhpDocUtil::matchTaintEscape($queryExpr, $scope)) {
                 return '1';
             }
 

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -201,6 +201,10 @@ final class QueryReflection
         }
 
         if ($queryExpr instanceof Expr\CallLike) {
+            if (PhpDocUtil::matchTaintEscape($queryExpr, $scope) === 'sql') {
+                return '1';
+            }
+
             $placeholder = PhpDocUtil::matchStringAnnotation('@phpstandba-inference-placeholder', $queryExpr, $scope);
 
             if (null !== $placeholder) {

--- a/tests/default/Fixture/Escaper.php
+++ b/tests/default/Fixture/Escaper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace staabm\PHPStanDba\Tests\Fixture;
+
+final class Escaper {
+    /**
+     * @psalm-taint-escape sql
+     *
+     * @return string
+     */
+    public function escape($s):string {
+
+    }
+
+    /**
+     * @psalm-taint-escape sql
+     *
+     * @return string
+     */
+    static public function staticEscape($s):string {
+
+    }
+}

--- a/tests/default/Fixture/Escaper.php
+++ b/tests/default/Fixture/Escaper.php
@@ -2,22 +2,19 @@
 
 namespace staabm\PHPStanDba\Tests\Fixture;
 
-final class Escaper {
+final class Escaper
+{
     /**
      * @psalm-taint-escape sql
-     *
-     * @return string
      */
-    public function escape($s):string {
-
+    public function escape($s): string
+    {
     }
 
     /**
      * @psalm-taint-escape sql
-     *
-     * @return string
      */
-    static public function staticEscape($s):string {
-
+    public static function staticEscape($s): string
+    {
     }
 }

--- a/tests/default/data/pdo.php
+++ b/tests/default/data/pdo.php
@@ -3,6 +3,7 @@
 namespace PdoTest;
 
 use PDO;
+use staabm\PHPStanDba\Tests\Fixture\Escaper;
 use function PHPStan\Testing\assertType;
 
 class Foo
@@ -222,6 +223,19 @@ class Foo
             return self::INT;
         };
         $stmt = $pdo->query("SELECT email, adaid FROM ada WHERE adaid={$fn()}", PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<-32768, 32767>}>', $stmt);
+    }
+
+    public function taintStaticEscaped(PDO $pdo, string $s)
+    {
+        $stmt = $pdo->query("SELECT email, adaid FROM ada WHERE adaid=". Escaper::staticEscape($s), PDO::FETCH_ASSOC);
+        assertType('PDOStatement<array{email: string, adaid: int<-32768, 32767>}>', $stmt);
+    }
+
+    public function taintEscaped(PDO $pdo, string $s)
+    {
+        $escapeer = new Escaper();
+        $stmt = $pdo->query("SELECT email, adaid FROM ada WHERE adaid=". $escapeer->escape($s), PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<-32768, 32767>}>', $stmt);
     }
 }

--- a/tests/default/data/pdo.php
+++ b/tests/default/data/pdo.php
@@ -3,8 +3,8 @@
 namespace PdoTest;
 
 use PDO;
-use staabm\PHPStanDba\Tests\Fixture\Escaper;
 use function PHPStan\Testing\assertType;
+use staabm\PHPStanDba\Tests\Fixture\Escaper;
 
 class Foo
 {
@@ -228,14 +228,14 @@ class Foo
 
     public function taintStaticEscaped(PDO $pdo, string $s)
     {
-        $stmt = $pdo->query("SELECT email, adaid FROM ada WHERE adaid=". Escaper::staticEscape($s), PDO::FETCH_ASSOC);
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.Escaper::staticEscape($s), PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<-32768, 32767>}>', $stmt);
     }
 
     public function taintEscaped(PDO $pdo, string $s)
     {
         $escapeer = new Escaper();
-        $stmt = $pdo->query("SELECT email, adaid FROM ada WHERE adaid=". $escapeer->escape($s), PDO::FETCH_ASSOC);
+        $stmt = $pdo->query('SELECT email, adaid FROM ada WHERE adaid='.$escapeer->escape($s), PDO::FETCH_ASSOC);
         assertType('PDOStatement<array{email: string, adaid: int<-32768, 32767>}>', $stmt);
     }
 }


### PR DESCRIPTION
conditional tainted input is not yet supported
https://psalm.dev/docs/security_analysis/avoiding_false_positives/#conditional-escaping-tainted-input