### PR TITLE
Dibi phase two

### DIFF
--- a/config/extensions.neon
+++ b/config/extensions.neon
@@ -90,3 +90,8 @@ services:
         class: staabm\PHPStanDba\Ast\PreviousConnectingVisitor
         tags:
         	- phpstan.parser.richParserNodeVisitor
+
+    -
+        class: staabm\PHPStanDba\Extensions\DibiConnectionFetchDynamicReturnTypeExtension
+        tags:
+        	- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/config/rules.neon
+++ b/config/rules.neon
@@ -1,5 +1,16 @@
 services:
     -
+        class: staabm\PHPStanDba\Rules\SyntaxErrorInDibiPreparedStatementMethodRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            classMethods:
+                - 'Dibi\Connection::fetch'
+                - 'Dibi\Connection::fetchSingle'
+                - 'Dibi\Connection::query'
+                - 'Dibi\Connection::fetchAll'
+                - 'Dibi\Connection::fetchPairs'
+
+    -
         class: staabm\PHPStanDba\Rules\SyntaxErrorInPreparedStatementMethodRule
         tags: [phpstan.rules.rule]
         arguments:
@@ -24,11 +35,6 @@ services:
                 - 'Doctrine\DBAL\Connection::iterateAssociativeIndexed'
                 - 'Doctrine\DBAL\Connection::iterateColumn'
                 - 'Doctrine\DBAL\Connection::executeUpdate' # deprecated in doctrine
-                - 'Dibi\Connection::fetch'
-                - 'Dibi\Connection::fetchSingle'
-                - 'Dibi\Connection::query'
-                - 'Dibi\Connection::fetchAll'
-                - 'Dibi\Connection::fetchPairs'
 
     -
         class: staabm\PHPStanDba\Rules\PdoStatementExecuteMethodRule

--- a/src/Analyzer/QueryPlanAnalyzerMysql.php
+++ b/src/Analyzer/QueryPlanAnalyzerMysql.php
@@ -25,12 +25,12 @@ final class QueryPlanAnalyzerMysql
     public const DEFAULT_SMALL_TABLE_THRESHOLD = QueryPlanAnalyzer::DEFAULT_SMALL_TABLE_THRESHOLD;
 
     /**
-     * @var PDO|mysqli
+     * @var \Dibi\Connection|PDO|mysqli
      */
     private $connection;
 
     /**
-     * @param PDO|mysqli $connection
+     * @param \Dibi\Connection|PDO|mysqli $connection
      */
     public function __construct($connection)
     {

--- a/src/DbSchema/SchemaHasherMysql.php
+++ b/src/DbSchema/SchemaHasherMysql.php
@@ -11,7 +11,7 @@ use PHPStan\ShouldNotHappenException;
 final class SchemaHasherMysql
 {
     /**
-     * @var PDO|mysqli
+     * @var \Dibi\Connection|PDO|mysqli
      */
     private $connection;
 
@@ -21,7 +21,7 @@ final class SchemaHasherMysql
     private $hash = null;
 
     /**
-     * @param PDO|mysqli $connection
+     * @param \Dibi\Connection|PDO|mysqli $connection
      */
     public function __construct($connection)
     {
@@ -62,6 +62,11 @@ final class SchemaHasherMysql
         $hash = '';
         if ($this->connection instanceof PDO) {
             $stmt = $this->connection->query($query);
+            foreach ($stmt as $row) {
+                $hash = $row['dbsignature'] ?? '';
+            }
+        } elseif ($this->connection instanceof \Dibi\Connection) {
+            $stmt = $this->connection->query($query)->fetchAll();
             foreach ($stmt as $row) {
                 $hash = $row['dbsignature'] ?? '';
             }

--- a/src/Extensions/DibiConnectionFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/DibiConnectionFetchDynamicReturnTypeExtension.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Extensions;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
+use staabm\PHPStanDba\UnresolvableQueryException;
+
+final class DibiConnectionFetchDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return \Dibi\Connection::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), [
+            'fetch',
+            'fetchAll',
+            'fetchPairs',
+            'fetchSingle',
+        ], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $args = $methodCall->getArgs();
+        $defaultReturn = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $methodCall->getArgs(),
+            $methodReflection->getVariants(),
+        )->getReturnType();
+
+        if (\count($args) < 1) {
+            return $defaultReturn;
+        }
+
+        if ($scope->getType($args[0]->value) instanceof MixedType) {
+            return $defaultReturn;
+        }
+
+        try {
+            $resultType = $this->inferType($args[0]->value, $scope, $methodReflection->getName());
+            if (null !== $resultType) {
+                return $resultType;
+            }
+        } catch (UnresolvableQueryException $exception) {
+            // simulation not possible.. use default value
+        }
+
+        return $defaultReturn;
+    }
+
+    private function inferType(Expr $queryExpr, Scope $scope, string $methodName): ?Type
+    {
+        $queryReflection = new QueryReflection();
+        $resolvedQuery = $queryReflection->resolveQueryString($queryExpr, $scope);
+
+        if (null === $resolvedQuery) {
+            return null;
+        }
+
+        $result = $queryReflection->getResultType($resolvedQuery, QueryReflector::FETCH_TYPE_COLUMN);
+
+        if ('fetch' === $methodName && null !== $result) {
+            return new UnionType([new NullType(), $result]);
+        } elseif ('fetchAll' === $methodName && null !== $result) {
+            return new ArrayType(new IntegerType(), $result);
+        } elseif ('fetchPairs' === $methodName && $result instanceof ConstantArrayType && 2 === \count($result->getValueTypes())) {
+            return new ArrayType($result->getValueTypes()[0], $result->getValueTypes()[1]);
+        } elseif ('fetchSingle' === $methodName && $result instanceof ConstantArrayType && 1 === \count($result->getValueTypes())) {
+            return $result->getValueTypes()[0];
+        }
+
+        return null;
+    }
+}

--- a/src/QueryReflection/DibiQueryReflector.php
+++ b/src/QueryReflection/DibiQueryReflector.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\QueryReflection;
+
+use Dibi\Connection;
+use Dibi\ConstraintViolationException;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use staabm\PHPStanDba\Error;
+use staabm\PHPStanDba\TypeMapping\MysqliTypeMapper;
+
+final class DibiQueryReflector implements QueryReflector, RecordingReflector
+{
+    public const NAME = 'dibi-mysql';
+
+    /** @var array<string, \Throwable|list<object>|null> */
+    private $cache = [];
+
+    /** @var Connection */
+    private $connection;
+
+    /**
+     * @var MysqliTypeMapper
+     */
+    private $typeMapper;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+        $this->typeMapper = new MysqliTypeMapper();
+    }
+
+    public function validateQueryString(string $queryString): ?Error
+    {
+        $result = $this->simulateQuery($queryString);
+
+        if ($result instanceof \Throwable) {
+            return new Error($result->getMessage(), $result->getCode());
+        }
+
+        return null;
+    }
+
+    /**
+     * @param self::FETCH_TYPE* $fetchType
+     */
+    public function getResultType(string $queryString, int $fetchType): ?Type
+    {
+        /** @var array<\Dibi\Reflection\Column> $result */
+        $result = $this->simulateQuery($queryString);
+
+        if (!\is_array($result)) {
+            return null;
+        }
+
+        $arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+
+        foreach ($result as $val) {
+            $type = new MixedType();
+
+            if (is_numeric($val->getVendorInfo('type')) && is_numeric($val->getVendorInfo('flags')) && is_numeric($val->getVendorInfo('length'))) {
+                $type = $this->typeMapper->mapToPHPStanType((int) $val->getVendorInfo('type'), (int) $val->getVendorInfo('flags'), (int) $val->getVendorInfo('length'));
+            }
+
+            $arrayBuilder->setOffsetValueType(new ConstantStringType($val->getName()), $type);
+        }
+
+        return $arrayBuilder->getArray();
+    }
+
+    /**
+     * @return \Throwable|list<object>|null
+     */
+    private function simulateQuery(string $queryString)
+    {
+        $originalQueryString = $queryString;
+
+        if (\array_key_exists($originalQueryString, $this->cache)) {
+            return $this->cache[$originalQueryString];
+        }
+
+        $queryString = str_replace('%in', '(1)', $queryString);
+        $queryString = str_replace('%lmt', 'LIMIT 1', $queryString);
+        $queryString = str_replace('%ofs', ', 1', $queryString);
+        $queryString = preg_replace('#%(i|s)#', '"1"', $queryString) ?? '';
+        $queryString = preg_replace('#%(t|d)#', '"2000-1-1"', $queryString) ?? '';
+        $queryString = preg_replace('#%(and|or)#', '(1 = 1)', $queryString) ?? '';
+        $queryString = preg_replace('#%~?like~?#', '"%1%"', $queryString) ?? '';
+
+        if (strpos($queryString, '%n') > 0) {
+            $queryString = null;
+        } elseif (strpos($queryString, '%ex') > 0) {
+            $queryString = null;
+        } elseif (0 !== preg_match('#^\s*(START|ROLLBACK|SET|SAVEPOINT|SHOW)#i', $queryString)) {
+            $queryString = null;
+        }
+
+        if (null === $queryString) {
+            return $this->cache[$originalQueryString] = null;
+        }
+
+        $this->connection->query('START transaction');
+
+        try {
+            $result = $this->connection->query($queryString);
+            $resultInfo = $result->getColumns();
+
+            return $this->cache[$originalQueryString] = $resultInfo;
+        } catch (ConstraintViolationException $e) {
+            return $this->cache[$originalQueryString] = null;
+        } catch (\Dibi\DriverException|\Dibi\Exception $e) {
+            return $this->cache[$originalQueryString] = $e;
+        } finally {
+            $this->connection->query('ROLLBACK');
+        }
+    }
+
+    public function getDatasource()
+    {
+        return $this->connection;
+    }
+}

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -51,9 +51,9 @@ final class QueryReflection
 
     public function validateQueryString(string $queryString): ?Error
     {
-        if ('SELECT' !== $this->getQueryType($queryString)) {
-            return null;
-        }
+//        if ('SELECT' !== $this->getQueryType($queryString)) {
+//            return null;
+//        }
 
         // this method cannot validate queries which contain placeholders.
         if (0 !== $this->countPlaceholders($queryString)) {
@@ -370,7 +370,7 @@ final class QueryReflection
         return $queryString;
     }
 
-    private static function reflector(): QueryReflector
+    public static function reflector(): QueryReflector
     {
         if (null === self::$reflector) {
             throw new DbaException('Reflector not initialized. Make sure a phpstan bootstrap file is configured which calls '.__CLASS__.'::setupReflector().');

--- a/src/QueryReflection/RecordingReflector.php
+++ b/src/QueryReflection/RecordingReflector.php
@@ -12,7 +12,7 @@ interface RecordingReflector
      * Beware this might establish a database connection, in case a reflector is implemented lazily.
      * Therefore calling this method might have a negative performance impact.
      *
-     * @return \mysqli|\PDO|null
+     * @return \Dibi\Connection|\mysqli|\PDO|null
      */
     public function getDatasource();
 }

--- a/src/Rules/SyntaxErrorInDibiPreparedStatementMethodRule.php
+++ b/src/Rules/SyntaxErrorInDibiPreparedStatementMethodRule.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use staabm\PHPStanDba\QueryReflection\QueryReflection;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
+
+/**
+ * @implements Rule<CallLike>
+ *
+ * @see SyntaxErrorInDibiPreparedStatementMethodRuleTest
+ */
+final class SyntaxErrorInDibiPreparedStatementMethodRule implements Rule
+{
+    /**
+     * @var list<string>
+     */
+    private $classMethods;
+
+    /**
+     * @param list<string> $classMethods
+     */
+    public function __construct(array $classMethods)
+    {
+        $this->classMethods = $classMethods;
+    }
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    public function processNode(Node $callLike, Scope $scope): array
+    {
+        if ($callLike instanceof MethodCall) {
+            if (!$callLike->name instanceof Node\Identifier) {
+                return [];
+            }
+
+            $methodReflection = $scope->getMethodReflection($scope->getType($callLike->var), $callLike->name->toString());
+        } elseif ($callLike instanceof New_) {
+            if (!$callLike->class instanceof FullyQualified) {
+                return [];
+            }
+            $methodReflection = $scope->getMethodReflection(new ObjectType($callLike->class->toCodeString()), '__construct');
+        } else {
+            return [];
+        }
+
+        if (null === $methodReflection) {
+            return [];
+        }
+
+        $unsupportedMethod = true;
+        foreach ($this->classMethods as $classMethod) {
+            sscanf($classMethod, '%[^::]::%s', $className, $methodName);
+            if (!\is_string($className) || !\is_string($methodName)) {
+                throw new ShouldNotHappenException('Invalid classMethod definition');
+            }
+
+            if ($methodName === $methodReflection->getName() &&
+                ($methodReflection->getDeclaringClass()->getName() === $className || $methodReflection->getDeclaringClass()->isSubclassOf($className))) {
+                $unsupportedMethod = false;
+                break;
+            }
+        }
+
+        if ($unsupportedMethod) {
+            return [];
+        }
+
+        return $this->checkErrors($callLike, $scope, $methodReflection);
+    }
+
+    /**
+     * @param MethodCall|New_ $callLike
+     *
+     * @return RuleError[]
+     */
+    private function checkErrors(CallLike $callLike, Scope $scope, MethodReflection $methodReflection): array
+    {
+        $args = $callLike->getArgs();
+
+        if (\count($args) < 1) {
+            return [];
+        }
+
+        $queryReflection = new QueryReflection();
+        $queryParameters = [];
+        $errors = [];
+
+        foreach ($args as $arg) {
+            $parameterExpr = $arg->value;
+            $parameterType = $scope->getType($parameterExpr);
+
+            if ($parameterType instanceof StringType) {
+                $resolvedString = $queryReflection->resolveQueryString($parameterExpr, $scope);
+
+                if (null === $resolvedString) {
+                    $queryParameters[] = $parameterType;
+                } else {
+                    $queryParameters[] = $resolvedString;
+                }
+            } elseif ($parameterType instanceof ConstantArrayType) {
+                $constantArray = [];
+
+                foreach ($parameterType->getKeyTypes() as $i => $keyType) {
+                    $constantArray[$keyType->getValue()] = $parameterType->getValueTypes()[$i];
+                }
+
+                $queryParameters[] = $constantArray;
+            } else {
+                $queryParameters[] = $parameterType;
+            }
+        }
+
+        if (!\is_string($queryParameters[0])) {
+            return [];
+        }
+
+        $stringParameterCount = 0;
+
+        foreach ($queryParameters as $queryParameter) {
+            if (\is_string($queryParameter)) {
+                $stringParameterCount = $stringParameterCount + 1;
+            }
+        }
+
+        $placeholders = [];
+        preg_match_all('#%(ex|in|i|and|or|s|t|d|~?like~?|n|lmt|ofs)#', $queryParameters[0], $placeholders, \PREG_SET_ORDER);
+        $placeholderCount = \count($placeholders);
+        $parameterCount = \count($queryParameters) - 1;
+
+        if (1 === $stringParameterCount && 'INSERT' !== QueryReflection::getQueryType($queryParameters[0])) {
+            if ($parameterCount !== $placeholderCount) {
+                $placeholderExpectation = sprintf('Query expects %s placeholder', $placeholderCount);
+                if ($placeholderCount > 1) {
+                    $placeholderExpectation = sprintf('Query expects %s placeholders', $placeholderCount);
+                }
+
+                if (0 === $parameterCount) {
+                    $parameterActual = 'but no values are given';
+                } else {
+                    $parameterActual = sprintf('but %s value is given', $parameterCount);
+                    if ($parameterCount > 1) {
+                        $parameterActual = sprintf('but %s values are given', $parameterCount);
+                    }
+                }
+
+                return [
+                    RuleErrorBuilder::message($placeholderExpectation.', '.$parameterActual.'.')->line($callLike->getLine())->build(),
+                ];
+            }
+        }
+
+        if ($stringParameterCount > 1) {
+            // means syntax like `query('update app set', [...], ' where x = %i', 1)`
+            return [];
+        }
+
+        if ($placeholderCount !== $parameterCount) {
+            // means syntax like `query('insert into app', [...])`
+            return [];
+        }
+
+        $validity = $queryReflection->validateQueryString($queryParameters[0]);
+
+        if (null !== $validity) {
+            return [RuleErrorBuilder::message($validity->asRuleMessage())->line($callLike->getLine())->build()];
+        }
+
+        $result = $queryReflection->getResultType($queryParameters[0], QueryReflector::FETCH_TYPE_BOTH);
+
+        if ('fetchPairs' === $methodReflection->getName() && $result instanceof ConstantArrayType && 2 !== \count($result->getValueTypes())) {
+            return [RuleErrorBuilder::message('fetchPairs requires exactly 2 selected columns, got '.\count($result->getValueTypes()).'.')->line($callLike->getLine())->build()];
+        }
+
+        if ('fetchSingle' === $methodReflection->getName() && $result instanceof ConstantArrayType && 1 !== \count($result->getValueTypes())) {
+            return [RuleErrorBuilder::message('fetchSingle requires exactly 1 selected column, got '.\count($result->getValueTypes()).'.')->line($callLike->getLine())->build()];
+        }
+
+        return $errors;
+    }
+}

--- a/tests/ReflectorFactory.php
+++ b/tests/ReflectorFactory.php
@@ -2,9 +2,11 @@
 
 namespace staabm\PHPStanDba\Tests;
 
+use Dibi\Connection;
 use mysqli;
 use PDO;
 use staabm\PHPStanDba\DbSchema\SchemaHasherMysql;
+use staabm\PHPStanDba\QueryReflection\DibiQueryReflector;
 use staabm\PHPStanDba\QueryReflection\MysqliQueryReflector;
 use staabm\PHPStanDba\QueryReflection\PdoMysqlQueryReflector;
 use staabm\PHPStanDba\QueryReflection\PdoPgSqlQueryReflector;
@@ -65,6 +67,15 @@ final class ReflectorFactory
                 $pdo = new PDO(sprintf('mysql:dbname=%s;host=%s', $dbname, $host), $user, $password);
                 $reflector = new PdoMysqlQueryReflector($pdo);
                 $schemaHasher = new SchemaHasherMysql($pdo);
+            } elseif ('dibi-mysql' === $reflector) {
+                $connection = new Connection([
+                    'host' => $host,
+                    'username' => $user,
+                    'password' => $password,
+                    'database' => $dbname,
+                ]);
+                $reflector = new DibiQueryReflector($connection);
+                $schemaHasher = new SchemaHasherMysql($connection);
             } elseif ('pdo-pgsql' === $reflector) {
                 $pdo = new PDO(sprintf('pgsql:dbname=%s;host=%s', $dbname, $host), $user, $password);
                 $reflector = new PdoPgSqlQueryReflector($pdo);

--- a/tests/rules/SyntaxErrorInDibiPreparedStatementMethodRuleTest.php
+++ b/tests/rules/SyntaxErrorInDibiPreparedStatementMethodRuleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace staabm\PHPStanDba\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use staabm\PHPStanDba\QueryReflection\DibiQueryReflector;
+use staabm\PHPStanDba\Rules\SyntaxErrorInDibiPreparedStatementMethodRule;
+
+/**
+ * @extends RuleTestCase<SyntaxErrorInDibiPreparedStatementMethodRule>
+ */
+class SyntaxErrorInDibiPreparedStatementMethodRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(SyntaxErrorInDibiPreparedStatementMethodRule::class);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/../../config/dba.neon',
+        ];
+    }
+
+    public function testSyntaxErrorInQueryRule(): void
+    {
+        if (\PHP_VERSION_ID < 70400) {
+            self::markTestSkipped('Test requires PHP 7.4.');
+        }
+
+        if (DibiQueryReflector::NAME === getenv('DBA_REFLECTOR')) {
+            $expectedErrors = [
+                [
+                    "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM ada' at line 1 (1064).",
+                    13,
+                ],
+                [
+                    "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM ada' at line 1 (1064).",
+                    19,
+                ],
+                [
+                    "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM ada' at line 1 (1064).",
+                    25,
+                ],
+                [
+                    'fetchSingle requires exactly 1 selected column, got 2.',
+                    26,
+                ],
+                [
+                    "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM ada' at line 1 (1064).",
+                    32,
+                ],
+                [
+                    'fetchPairs requires exactly 2 selected columns, got 1.',
+                    33,
+                ],
+                [
+                    'Query expects 1 placeholder, but no values are given.',
+                    39,
+                ],
+                [
+                    'Query expects 0 placeholder, but 1 value is given.',
+                    40,
+                ],
+                [
+                    "Query error: Table 'phpstan_dba.adasfd' doesn't exist (1146).",
+                    46,
+                ],
+            ];
+        } else {
+            throw new \RuntimeException('Unsupported DBA_REFLECTOR '.getenv('DBA_REFLECTOR'));
+        }
+
+        require_once __DIR__.'/data/syntax-error-in-dibi-prepared-statement.php';
+        $this->analyse([__DIR__.'/data/syntax-error-in-dibi-prepared-statement.php'], $expectedErrors);
+    }
+}

--- a/tests/rules/SyntaxErrorInPreparedStatementMethodRuleTest.php
+++ b/tests/rules/SyntaxErrorInPreparedStatementMethodRuleTest.php
@@ -78,26 +78,6 @@ class SyntaxErrorInPreparedStatementMethodRuleTest extends RuleTestCase
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'gesperrt freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",
                 319,
             ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (1064).",
-                335,
-            ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (1064).",
-                336,
-            ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (1064).",
-                337,
-            ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (1064).",
-                338,
-            ],
-            [
-                "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (1064).",
-                339,
-            ],
         ];
         } elseif (PdoPgSqlQueryReflector::NAME === getenv('DBA_REFLECTOR')) {
             $expectedErrors = [
@@ -167,36 +147,6 @@ LINE 1: SELECT email adaid gesperrt freigabe1u1 FROM ada LIMIT 0
                            ^ (42601).',
                     319,
                 ],
-                [
-                    'Query error: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "FROM"
-LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
-                                          ^ (42601).',
-                    335,
-                ],
-                [
-                    'Query error: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "FROM"
-LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
-                                          ^ (42601).',
-                    336,
-                ],
-                [
-                    'Query error: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "FROM"
-LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
-                                          ^ (42601).',
-                    337,
-                ],
-                [
-                    'Query error: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "FROM"
-LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
-                                          ^ (42601).',
-                    338,
-                ],
-                [
-                    'Query error: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "FROM"
-LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
-                                          ^ (42601).',
-                    339,
-                ],
             ];
         } elseif (PdoMysqlQueryReflector::NAME === getenv('DBA_REFLECTOR')) {
             $expectedErrors = [
@@ -243,26 +193,6 @@ LINE 1: SELECT email adaid WHERE gesperrt FROM ada LIMIT 0
                 [
                     "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'gesperrt freigabe1u1 FROM ada LIMIT 0' at line 1 (42000).",
                     319,
-                ],
-                [
-                    "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (42000).",
-                    335,
-                ],
-                [
-                    "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (42000).",
-                    336,
-                ],
-                [
-                    "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (42000).",
-                    337,
-                ],
-                [
-                    "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (42000).",
-                    338,
-                ],
-                [
-                    "Query error: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'FROM ada LIMIT 0' at line 1 (42000).",
-                    339,
                 ],
             ];
         } else {

--- a/tests/rules/data/syntax-error-in-dibi-prepared-statement.php
+++ b/tests/rules/data/syntax-error-in-dibi-prepared-statement.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SyntaxErrorInDibiPreparedStatementMethodRuleTest;
+
+use staabm\PHPStanDba\Tests\Fixture\Connection;
+use staabm\PHPStanDba\Tests\Fixture\PreparedStatement;
+
+class Foo
+{
+
+    public function testQuery(\Dibi\Connection $conn)
+    {
+        $conn->query('SELECT email adaid WHERE gesperrt FROM ada');
+        $conn->query('SELECT email,adaid FROM ada');
+    }
+
+    public function testFetch(\Dibi\Connection $conn)
+    {
+        $conn->fetch('SELECT email adaid WHERE gesperrt FROM ada');
+        $conn->fetch('SELECT email,adaid FROM ada');
+    }
+
+    public function testFetchSingle(\Dibi\Connection $conn)
+    {
+        $conn->fetchSingle('SELECT email adaid WHERE gesperrt FROM ada');
+        $conn->fetchSingle('SELECT email,adaid FROM ada');
+        $conn->fetchSingle('SELECT email FROM ada');
+    }
+
+    public function testFetchPairs(\Dibi\Connection $conn)
+    {
+        $conn->fetchPairs('SELECT email adaid WHERE gesperrt FROM ada');
+        $conn->fetchPairs('SELECT email FROM ada');
+        $conn->fetchPairs('SELECT email,adaid FROM ada');
+    }
+
+    public function testPlaceholders(\Dibi\Connection $conn)
+    {
+        $conn->fetchPairs('SELECT email FROM ada where email = %s');
+        $conn->fetchPairs('SELECT email FROM ada where email = ""', 1);
+        $conn->fetchPairs('SELECT email FROM ada where email = %s', 'email@github.com');
+    }
+
+    public function testDeleteUpdateInsert(\Dibi\Connection $conn)
+    {
+        $conn->query('DELETE from adasfd');
+        $conn->query('DELETE from ada');
+        $conn->query('UPDATE ada set email = ""');
+        $conn->query('INSERT into ada', [
+            'email' => 'sdf',
+        ]);
+        $conn->query('INSERT into %n', 'ada', [
+            'email' => 'sdf',
+        ]);
+    }
+
+}

--- a/tests/rules/data/syntax-error-in-prepared-statement.php
+++ b/tests/rules/data/syntax-error-in-prepared-statement.php
@@ -329,21 +329,4 @@ class Foo
         $conn->executeQuery("SELECT * FROM `$table`");
     }
 
-    public function dibiTest(\Dibi\Connection $conn)
-    {
-        // syntax error, should expect a error in the test
-        $conn->fetch('SELECT email adaid WHERE gesperrt FROM ada');
-        $conn->fetchSingle('SELECT email adaid WHERE gesperrt FROM ada');
-        $conn->query('SELECT email adaid WHERE gesperrt FROM ada');
-        $conn->fetchPairs('SELECT email adaid WHERE gesperrt FROM ada');
-        $conn->fetchAll('SELECT email adaid WHERE gesperrt FROM ada');
-        // all good, no error expected
-        $conn->fetch('SELECT email, adaid FROM ada');
-        $conn->fetchSingle('SELECT email, adaid FROM ada');
-        $conn->query('SELECT email, adaid FROM ada');
-        $conn->fetchPairs('SELECT email, adaid FROM ada');
-        $conn->fetchAll('SELECT email, adaid FROM ada');
-        $conn->query('UPDATE ada set', ['email' => 'test@github.com'], ' where adaid = 1');
-    }
-
 }


### PR DESCRIPTION
I had to revert some of the changes from the last commit. The syntax in between dibi and mysqli is so different that I decided to create new `rule` `SyntaxErrorInDibiPreparedStatementMethodRule` (mainly due to how parameters and placeholders were treated)

I also added driver `dibi-mysql` into tests (but not sure whether they will be executed, pipelines are not running in my fork). The tests for other rules are now failing on `Unsupported DBA_REFLECTOR` when I manually used `DBA_REFLECTOR` environment value. 

I wasnt sure whether it should be resolved tho, why should the test cases that have nothing to do with `dibi-mysql` support it.

Please let me know what do you think. I used this on our codebase which has around 100k lines and it worked (it actually helped us find a few issues that we overlooked).

Also, there is one phpstan rule failing, the `staabm\PHPStanDba\Error` seems kinda strict when it comes to `$code`. In my reflector it's just some integer (I dont really care what the code was, it failed and the message displayed by phpstan is clear enough), 

Thanks
Jakub