### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "staabm/phpstan-dba",
 	"type": "phpstan-extension",
 	"license": "MIT",
+	"keywords": ["dev"],
 	"require": {
 		"php": "^7.3 || ^8.0",
 		"composer-runtime-api": "^2.0",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency