### PR TITLE
Fix wrong deprecated annotation

### DIFF
--- a/src/QueryReflection/PdoQueryReflector.php
+++ b/src/QueryReflection/PdoQueryReflector.php
@@ -9,7 +9,7 @@ use PDO;
 /**
  * This class was kept for BC reasons.
  *
- * @deprected use PdoMysqlQueryReflector instead
+ * @deprecated use PdoMysqlQueryReflector instead
  */
 final class PdoQueryReflector extends PdoMysqlQueryReflector // @phpstan-ignore-line
 {


### PR DESCRIPTION
Before the change PHPStorm suggest the misspelling in auto-completion which is a bit annoying :grin: