### PR TITLE
enable rules for project internal analysis

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - config/stubFiles.neon
     - config/extensions.neon
+    - config/rules.neon
     - phpstan-baseline.neon
 
 parameters:


### PR DESCRIPTION
to allow analyzing test files with `vendor/bin/phpstan analyze test.php --debug`