### PR TITLE
DoctrineKeyValueStyleRule: improve table error message

### DIFF
--- a/src/Rules/DoctrineKeyValueStyleRule.php
+++ b/src/Rules/DoctrineKeyValueStyleRule.php
@@ -111,7 +111,7 @@ final class DoctrineKeyValueStyleRule implements Rule
         $tableType = $scope->getType($tableExpr);
         if (! $tableType instanceof ConstantStringType) {
             return [
-                RuleErrorBuilder::message('Argument #0 expects a literal string, got ' . $tableType->describe(VerbosityLevel::precise()))->line($callLike->getLine())->build(),
+                RuleErrorBuilder::message('Argument #0 expects a constant string, got ' . $tableType->describe(VerbosityLevel::precise()))->line($callLike->getLine())->build(),
             ];
         }
 

--- a/tests/rules/DoctrineKeyValueStyleRuleTest.php
+++ b/tests/rules/DoctrineKeyValueStyleRuleTest.php
@@ -29,7 +29,7 @@ class DoctrineKeyValueStyleRuleTest extends RuleTestCase
     {
         $expectedErrors = [
             [
-                'Argument #0 expects a literal string, got string',
+                'Argument #0 expects a constant string, got string',
                 11,
             ],
             [


### PR DESCRIPTION
Table names must be constant strings, not literal strings.

As per https://github.com/staabm/phpstan-dba/issues/560#issuecomment-1464843621.