### PR TITLE
DoctrineKeyValueStyleRule: properly handle unions

### DIFF
--- a/tests/rules/DoctrineKeyValueStyleRuleTest.php
+++ b/tests/rules/DoctrineKeyValueStyleRuleTest.php
@@ -68,6 +68,22 @@ class DoctrineKeyValueStyleRuleTest extends RuleTestCase
                 'Query error: Column "ada.adaid" expects value type int, got type mixed',
                 56,
             ],
+            [
+                'Query error: Table "not_a_table1" does not exist',
+                112,
+            ],
+            [
+                'Query error: Table "not_a_table2" does not exist',
+                112,
+            ],
+            [
+                'Query error: Column "ada.not_a_column1" does not exist',
+                120,
+            ],
+            [
+                'Query error: Column "ada.not_a_column2" does not exist',
+                120,
+            ],
         ];
 
         $this->analyse([__DIR__ . '/data/doctrine-key-value-style.php'], $expectedErrors);

--- a/tests/rules/data/doctrine-key-value-style.php
+++ b/tests/rules/data/doctrine-key-value-style.php
@@ -6,7 +6,7 @@ use staabm\PHPStanDba\Tests\Fixture\Connection;
 
 class Foo
 {
-    public function errorIfTableIsNotLiteralString(Connection $conn, string $tableName)
+    public function errorIfTableIsNotConstantString(Connection $conn, string $tableName)
     {
         $conn->assembleNoArrays($tableName);
     }
@@ -102,5 +102,21 @@ class Foo
     public function noErrorWithBackticks(Connection $conn)
     {
         $conn->assembleOneArray('`ada`', ['`adaid`' => 1]);
+    }
+
+    /**
+     * @param 'ada'|'not_a_table1'|'not_a_table2' $table
+     */
+    public function errorInTableNameUnion(Connection $conn, string $table)
+    {
+        $conn->assembleNoArrays($table);
+    }
+
+    /**
+     * @param array{email: string}|array{not_a_column1: int}|array{not_a_column2: int} $params
+     */
+    public function errorInParamArrayUnion(Connection $conn, array $params)
+    {
+        $conn->assembleOneArray('ada', $params);
     }
 }


### PR DESCRIPTION
If any of the arguments (table name or parameter values) to the DoctrineKeyValueStyleRule methods are a union type, each subtype will now be checked independently.

Previously, union types would cause an error, because of the improper use of `instanceof *Type` checks. This is now fixed by using methods to get the constants, e.g. `getConstantStrings()`, as recommended in https://github.com/staabm/phpstan-dba/pull/564#discussion_r1133053061.