### PR TITLE
SQL AST: COUNT cannot return null

### DIFF
--- a/src/SqlAst/PositiveIntReturnTypeExtension.php
+++ b/src/SqlAst/PositiveIntReturnTypeExtension.php
@@ -6,7 +6,6 @@ namespace staabm\PHPStanDba\SqlAst;
 
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use SqlFtw\Sql\Expression\BuiltInFunction;
 use SqlFtw\Sql\Expression\FunctionCall;
 
@@ -31,12 +30,6 @@ final class PositiveIntReturnTypeExtension implements QueryFunctionReturnTypeExt
 
     public function getReturnType(FunctionCall $expression, QueryScope $scope): Type
     {
-        $positiveInt = IntegerRangeType::fromInterval(0, null);
-
-        if ($expression->getFunction()->getName() === BuiltInFunction::COUNT) {
-            return TypeCombinator::addNull($positiveInt);
-        }
-
-        return $positiveInt;
+        return IntegerRangeType::fromInterval(0, null);
     }
 }

--- a/tests/sqlAst/data/sql-ast-narrowing.php
+++ b/tests/sqlAst/data/sql-ast-narrowing.php
@@ -10,13 +10,13 @@ class Foo
     public function count(PDO $pdo): void
     {
         $stmt = $pdo->query('SELECT count(*) as myemail from ada');
-        assertType('PDOStatement<array{myemail: int<0, max>|null, 0: int<0, max>|null}>', $stmt);
+        assertType('PDOStatement<array{myemail: int<0, max>, 0: int<0, max>}>', $stmt);
 
         $stmt = $pdo->query('SELECT count(email) as myemail from ada');
-        assertType('PDOStatement<array{myemail: int<0, max>|null, 0: int<0, max>|null}>', $stmt);
+        assertType('PDOStatement<array{myemail: int<0, max>, 0: int<0, max>}>', $stmt);
 
         $stmt = $pdo->query('SELECT count(email) as myemail, count(email) from ada');
-        assertType('PDOStatement<array{myemail: int<0, max>|null, 0: int<0, max>|null, count(email): int<0, max>|null, 1: int<0, max>|null}>', $stmt);
+        assertType('PDOStatement<array{myemail: int<0, max>, 0: int<0, max>, count(email): int<0, max>, 1: int<0, max>}>', $stmt);
     }
 
     public function coalesce(PDO $pdo): void

--- a/tests/stringify/data/ast-narrowed-stringify.php
+++ b/tests/stringify/data/ast-narrowed-stringify.php
@@ -10,9 +10,9 @@ class SqlAstNarrowing
     public function count(PDO $pdo): void
     {
         $stmt = $pdo->query('SELECT count(email) as myemail from ada');
-        assertType('PDOStatement<array{myemail: numeric-string|null, 0: numeric-string|null}>', $stmt);
+        assertType('PDOStatement<array{myemail: numeric-string, 0: numeric-string}>', $stmt);
 
         $stmt = $pdo->query('SELECT count(email) as myemail, count(email) from ada');
-        assertType('PDOStatement<array{myemail: numeric-string|null, 0: numeric-string|null, count(email): numeric-string|null, 1: numeric-string|null}>', $stmt);
+        assertType('PDOStatement<array{myemail: numeric-string, 0: numeric-string, count(email): numeric-string, 1: numeric-string}>', $stmt);
     }
 }


### PR DESCRIPTION
Remove nullability from the PositiveIntReturnTypeExtension for the `COUNT` function case.

> If there are no matching rows, COUNT() returns 0. COUNT(NULL) returns 0.

(source: https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_count)