### PR TITLE
.gitattributes: remove diff attribute for cache files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 # mark cache files as generated files, so they don't show up in Pull Requests diffs
-.phpstan-dba-mysqli.cache linguist-generated=true
-.phpstan-dba-pdo-mysql.cache linguist-generated=true
-.phpunit-phpstan-dba-mysqli.cache linguist-generated=true
-.phpunit-phpstan-dba-pdo-mysql.cache linguist-generated=true
-.phpunit-phpstan-dba-pdo-pgsql.cache linguist-generated=true
+.phpstan-dba-mysqli.cache linguist-generated=true -diff
+.phpstan-dba-pdo-mysql.cache linguist-generated=true -diff
+.phpunit-phpstan-dba-mysqli.cache linguist-generated=true -diff
+.phpunit-phpstan-dba-pdo-mysql.cache linguist-generated=true -diff
+.phpunit-phpstan-dba-pdo-pgsql.cache linguist-generated=true -diff
 
 # Exclude non-essential files from dist
 /.github export-ignore


### PR DESCRIPTION
This makes git consider the cache files as binary for the purposes of operations like `git diff`, `git log`, `git grep`, etc. As a result, only meaningful content is displayed in full, making development activities much more manageable.

See https://git-scm.com/docs/gitattributes#_marking_files_as_binary for motivation.

Thinking beyond this PR, it would be nice if the tests generated and replayed their own cache files, instead of manually managing them as part of the development workflow. Making sure the cache files are correct has been one of the bigger struggles for me, especially because there isn't a way to easily set up a local testing environment that is consistent with the GitHub Actions environment (I made my own Docker setup for local testing, but it has some friction with the GHA design, and has been susceptible to subtle problems like generating incompatible cache files due to a different version of the SQL server). Is there any interest in something more auto-managed/self-contained?