### PR TITLE
Add a real matrix to Static analysis workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,10 +22,10 @@ jobs:
         db-image:
           - "mysql:8.0"
           - "mariadb:latest"
-        mode:
-          - "recording"
         reflector:
           - "mysqli"
+        mode:
+          - "recording"
 
         include:
           # PHPStan development version

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,6 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
-          - "8.3"
         db-image:
           - "mysql:8.0"
           - "mariadb:latest"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,6 +19,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         db-image:
           - "mysql:8.0"
           - "mariadb:latest"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -28,9 +28,16 @@ jobs:
           - "recording"
 
         include:
+          - db-image: "mysql:8.0"
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
+
+          - db-image: "mariadb:latest"
+            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
+
           # PHPStan development version
           - php-version: "8.0"
             db-image: "mysql:8.0"
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             phpstan-version: "dev"
@@ -38,12 +45,14 @@ jobs:
           # PDO MySQL reflector
           - php-version: "8.0"
             db-image: "mysql:8.0"
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
 
           # Replay and Recording mode
           - php-version: "8.1"
             db-image: "mysql:8.0"
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "replay-and-recording"
 
@@ -59,7 +68,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: ${{ startsWith(matrix.db-image, 'mariadb') && '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60' || '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' }}
+        options: ${{ matrix.db-options }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,42 +15,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php-version:
+          - "8.0"
+          - "8.1"
+          - "8.2"
+        db-image:
+          - "mysql:8.0"
+          - "mariadb:latest"
+        mode:
+          - "recording"
+        reflector:
+          - "mysqli"
+
         include:
+          # PHPStan development version
           - php-version: "8.0"
-            db-image: 'mysql:8.0'
+            db-image: "mysql:8.0"
             reflector: "pdo-mysql"
             mode: "recording"
-            phpstan-version: "phpstan@dev"
+            phpstan-version: "dev"
 
+          # PDO MySQL reflector
           - php-version: "8.0"
-            db-image: 'mysql:8.0'
+            db-image: "mysql:8.0"
             reflector: "pdo-mysql"
             mode: "recording"
-          - php-version: "8.0"
-            db-image: 'mysql:8.0'
-            reflector: "mysqli"
-            mode: "recording"
 
+          # Replay and Recording mode
           - php-version: "8.1"
-            db-image: 'mysql:8.0'
-            reflector: "mysqli"
-            mode: "recording"
-          - php-version: '8.1'
-            db-image: 'mariadb:latest'
-            reflector: "mysqli"
-            mode: "recording"
-
-          - php-version: "8.2"
-            db-image: 'mysql:8.0'
-            reflector: "mysqli"
-            mode: "recording"
-          - php-version: '8.2'
-            db-image: 'mariadb:latest'
-            reflector: "mysqli"
-            mode: "recording"
-
-          - php-version: "8.1"
-            db-image: 'mysql:8.0'
+            db-image: "mysql:8.0"
             reflector: "mysqli"
             mode: "replay-and-recording"
 
@@ -60,13 +53,13 @@ jobs:
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
-      mysql:
+      database:
         image: ${{ matrix.db-image }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: ${{ startsWith(matrix.db-image, 'mariadb') && '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60' || '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
 		"phpstan/phpstan-strict-rules": "^1.1",
 		"phpunit/phpunit": "^8.5|^9.5",
 		"symplify/easy-coding-standard": "^11.4",
-		"tomasvotruba/unused-public": "^0.2.0",
 		"vlucas/phpdotenv": "^5.4"
 	},
 	"conflict": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,11 +12,6 @@ parameters:
     paths:
         - src/
 
-    unused_public:
-        methods: true
-        properties: true
-        constants: true
-
     bootstrapFiles:
         - bootstrap.php
 


### PR DESCRIPTION
- Added a real 3×2×1×1 matrix + 3 "includes"
- Move database options to `db-options`
- PHP 8.0 + MariaDB was excluded - Should I exclude it now?
