### PR TITLE
Remove actions versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
         open-pull-requests-limit: 15
     -   package-ecosystem: github-actions
         directory: /
-        versioning-strategy: increase
         schedule:
             interval: daily
         open-pull-requests-limit: 15


### PR DESCRIPTION
Versioning strategies are not supported for actions.

From https://github.com/staabm/phpstan-dba/pull/614#issuecomment-1657066369
