### PR TITLE
Fix MariaDB health check

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,39 +18,47 @@ jobs:
         include:
           - php-version: "8.0"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             phpstan-version: "phpstan@dev"
 
           - php-version: "8.0"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
           - php-version: '8.1'
             db-image: 'mariadb:latest'
+            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.2"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
           - php-version: '8.2'
             db-image: 'mariadb:latest'
+            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "replay-and-recording"
 
@@ -60,13 +68,13 @@ jobs:
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
-      mysql:
+      database:
         image: ${{ matrix.db-image }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: ${{ matrix.db-options }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,47 +18,39 @@ jobs:
         include:
           - php-version: "8.0"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             phpstan-version: "phpstan@dev"
 
           - php-version: "8.0"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
           - php-version: '8.1'
             db-image: 'mariadb:latest'
-            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.2"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
           - php-version: '8.2'
             db-image: 'mariadb:latest'
-            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "replay-and-recording"
 
@@ -74,7 +66,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: ${{ matrix.db-options }}
+        options: ${{ startsWith(matrix.db-image, 'mariadb') && '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60' || '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 concurrency:
   group: tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
   cancel-in-progress: true
-  
+
 jobs:
 
   phpunit:
@@ -22,71 +22,84 @@ jobs:
         include:
           - php-version: "7.2"
             db-image: 'mysql:5.7'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-lowest"
 
           - php-version: "7.2"
             db-image: 'mysql:5.7'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "7.3"
             db-image: 'mysql:5.7'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "7.4"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: '8.1'
             db-image: 'mariadb:latest'
+            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.2"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: '8.2'
             db-image: 'mariadb:latest'
+            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "replay-and-recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "empty-recording"
             composer-options: "--prefer-dist"
           - php-version: "8.1"
             db-image: 'mysql:8.0'
+            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "empty-replay-and-recording"
             composer-options: "--prefer-dist"
@@ -97,13 +110,13 @@ jobs:
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
-      mysql:
+      database:
         image: ${{ matrix.db-image }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: ${{ matrix.db-options }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,84 +22,71 @@ jobs:
         include:
           - php-version: "7.2"
             db-image: 'mysql:5.7'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-lowest"
 
           - php-version: "7.2"
             db-image: 'mysql:5.7'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "7.3"
             db-image: 'mysql:5.7'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "7.4"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: "8.0"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: '8.1'
             db-image: 'mariadb:latest'
-            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.2"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
           - php-version: '8.2'
             db-image: 'mariadb:latest'
-            db-options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60'
             reflector: "mysqli"
             mode: "recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "replay-and-recording"
             composer-options: "--prefer-dist"
 
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "empty-recording"
             composer-options: "--prefer-dist"
           - php-version: "8.1"
             db-image: 'mysql:8.0'
-            db-options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3'
             reflector: "pdo-mysql"
             mode: "empty-replay-and-recording"
             composer-options: "--prefer-dist"
@@ -116,7 +103,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: ${{ matrix.db-options }}
+        options: ${{ startsWith(matrix.db-image, 'mariadb') && '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=1s --health-timeout=10s --health-retries=60' || '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
inspired by https://github.com/staabm/phpstan-dba/pull/613

extracted the parts which actually fix the current failling builds.
refactoring the matrix, like done in #613 should be a separate PR.

Co-authored-by: @szepeviktor 