### PR TITLE
Readd unused-public configuration to phpstan.neon.dist

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,11 @@ parameters:
     bootstrapFiles:
         - bootstrap.php
 
+    unused_public:
+        methods: true
+        properties: true
+        constants: true
+
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:


### PR DESCRIPTION
Accidentally removed in #613 