### PR TITLE
Fix "$result contains generic type mysqli_result<mixed> but class mysqli_result is not generic"

### DIFF
--- a/config/Mysqli.stub
+++ b/config/Mysqli.stub
@@ -16,14 +16,3 @@ class mysqli_result implements Traversable, IteratorAggregate
      */
     function fetch_object(string $class = 'stdClass', array $constructor_args = []) {}
 }
-
-/**
- * @template T of object
- * @template TValue
- *
- * @param mysqli_result<TValue> $result
- * @param class-string<T> $class
- * @param array<mixed> $constructor_args
- * @return T|null|false
- */
-function mysqli_fetch_object(mysqli_result $result, string $class = 'stdClass', array $constructor_args = []) {}


### PR DESCRIPTION
for now we remove support for `mysqli_fetch_object` in phpstan-dba to make phpstan-dba work for all other usescases again.
in a followup I will try to get rid of the stubs in phpstan-dba so we don't depend on changes of stubs in phpstans-src

closes https://github.com/staabm/phpstan-dba/issues/631