### PR TITLE
Support nested quotes

### DIFF
--- a/.phpstan-dba-mysqli.cache
+++ b/.phpstan-dba-mysqli.cache
@@ -1,280 +1,757 @@
 <?php return array (
   'schemaVersion' => 'v11-phpstan1_9_3-update',
-  'schemaHash' => 'f8243f08e312cc01a89e4e0e639e78ef',
+  'schemaHash' => '72813316a311d2e2b9384c458247d011',
   'records' => 
   array (
-    'SELECT
-                    coalesce(COLUMN_NAME, "") as COLUMN_NAME,
-                    coalesce(EXTRA, "") as EXTRA,
-                    COLUMN_TYPE
-                 FROM information_schema.columns
-                 WHERE table_name = \'1970-01-01\' AND table_schema = DATABASE()' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|\'COLUMN_NAME\'|\'COLUMN_TYPE\'|\'EXTRA\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'COLUMN_NAME',
-                 'isClassString' => false,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'COLUMN_TYPE',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'EXTRA',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 3,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'COLUMN_NAME',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'EXTRA',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'COLUMN_TYPE',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT
-                MD5(
-                    GROUP_CONCAT(
-                        CONCAT(
-                            COALESCE(COLUMN_NAME, ""),
-                            COALESCE(EXTRA, ""),
-                            COLUMN_TYPE,
-                            IS_NULLABLE
-                        )
-                    )
-                ) AS dbsignature,
-                1 AS grouper
-            FROM
-                information_schema.columns
-            WHERE
-                table_schema = DATABASE()
-            GROUP BY
-                grouper' => 
+    'SELECT * FROM ada' => 
     array (
       'result' => 
       array (
         3 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'dbsignature\'|\'grouper\'',
-              1 => 'string',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              1 => 'int<-2147483648, 2147483647>|string|null',
-            ),
              'types' => 
             array (
               0 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -2147483648,
-                 'max' => 2147483647,
+                 'min' => -32768,
+                 'max' => 32767,
               )),
               1 => 
               PHPStan\Type\StringType::__set_state(array(
               )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            2 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-                3 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
-    'SELECT column_name, column_default, is_nullable
-                FROM information_schema.columns
-                WHERE table_name = \'1970-01-01\'' => 
+    'SELECT email, adaid /* why? ? */ FROM ada /* just ?? :because ?*/ WHERE email = \'a\' -- ?' => 
     array (
       'result' => 
       array (
         5 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
-              2 => '0|1|2|\'column_default\'|\'column_name\'|\'is_nullable\'',
+              2 => '0|1|\'adaid\'|\'email\'',
             ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada -- :can have :more ? :placeholders? ?' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada -- nice :placeholder bro' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid = \'1\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
@@ -290,59 +767,53 @@
                  'value' => 2,
               )),
               3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'column_default',
-                 'isClassString' => false,
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
               )),
               4 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
                  'objectType' => NULL,
                  'arrayKeyType' => NULL,
-                 'value' => 'column_name',
-                 'isClassString' => false,
               )),
               5 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
                  'objectType' => NULL,
                  'arrayKeyType' => NULL,
-                 'value' => 'is_nullable',
+              )),
+              6 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
                  'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
             ),
              'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
+             'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 3,
-          ),
            'keyTypes' => 
           array (
             0 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
                'objectType' => NULL,
                'arrayKeyType' => NULL,
-               'value' => 'column_name',
-               'isClassString' => false,
             )),
             1 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
@@ -350,10 +821,10 @@
             )),
             2 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
                'objectType' => NULL,
                'arrayKeyType' => NULL,
-               'value' => 'column_default',
-               'isClassString' => false,
             )),
             3 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
@@ -361,14 +832,25 @@
             )),
             4 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
                'objectType' => NULL,
                'arrayKeyType' => NULL,
-               'value' => 'is_nullable',
-               'isClassString' => false,
             )),
             5 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
+            )),
+            6 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            7 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
             )),
           ),
            'valueTypes' => 
@@ -380,52 +862,59 @@
             PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\StringType::__set_state(array(
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
             )),
             5 => 
-            PHPStan\Type\StringType::__set_state(array(
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            6 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            7 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
           ),
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
+    ),
+    'Select * from ada
+            where adakzid = 15' => 
+    array (
+      'error' => 
+      staabm\PHPStanDba\Error::__set_state(array(
+         'message' => 'Unknown column \'adakzid\' in \'where clause\'',
+         'code' => 1054,
+      )),
     ),
   ),
   'runtimeConfig' => 

--- a/.phpstan-dba-pdo-mysql.cache
+++ b/.phpstan-dba-pdo-mysql.cache
@@ -1,502 +1,757 @@
 <?php return array (
   'schemaVersion' => 'v11-phpstan1_9_3-update',
-  'schemaHash' => 'f8243f08e312cc01a89e4e0e639e78ef',
+  'schemaHash' => '72813316a311d2e2b9384c458247d011',
   'records' => 
   array (
-    'SELECT
-                    coalesce(COLUMN_NAME, "") as COLUMN_NAME,
-                    coalesce(EXTRA, "") as EXTRA,
-                    COLUMN_TYPE
-                 FROM information_schema.columns
-                 WHERE table_name = \'1970-01-01\' AND table_schema = DATABASE()' => 
+    'SELECT * FROM ada' => 
     array (
       'result' => 
       array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|\'COLUMN_NAME\'|\'COLUMN_TYPE\'|\'EXTRA\'',
-              1 => 'int|string',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => 
-                  PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                     'objectType' => NULL,
-                     'arrayKeyType' => NULL,
-                     'value' => 'COLUMN_NAME',
-                     'isClassString' => false,
-                  )),
-                   'value' => 'COLUMN_NAME',
-                   'isClassString' => false,
-                )),
-                 'value' => 'COLUMN_NAME',
-                 'isClassString' => false,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => 
-                  PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                     'objectType' => NULL,
-                     'arrayKeyType' => NULL,
-                     'value' => 'COLUMN_TYPE',
-                     'isClassString' => false,
-                  )),
-                   'value' => 'COLUMN_TYPE',
-                   'isClassString' => false,
-                )),
-                 'value' => 'COLUMN_TYPE',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => 
-                  PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                     'objectType' => NULL,
-                     'arrayKeyType' => NULL,
-                     'value' => 'EXTRA',
-                     'isClassString' => false,
-                  )),
-                   'value' => 'EXTRA',
-                   'isClassString' => false,
-                )),
-                 'value' => 'EXTRA',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 3,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'COLUMN_NAME',
-                   'isClassString' => false,
-                )),
-                 'value' => 'COLUMN_NAME',
-                 'isClassString' => false,
-              )),
-               'value' => 'COLUMN_NAME',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'EXTRA',
-                   'isClassString' => false,
-                )),
-                 'value' => 'EXTRA',
-                 'isClassString' => false,
-              )),
-               'value' => 'EXTRA',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'COLUMN_TYPE',
-                   'isClassString' => false,
-                )),
-                 'value' => 'COLUMN_TYPE',
-                 'isClassString' => false,
-              )),
-               'value' => 'COLUMN_TYPE',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT
-                MD5(
-                    GROUP_CONCAT(
-                        CONCAT(
-                            COALESCE(COLUMN_NAME, ""),
-                            COALESCE(EXTRA, ""),
-                            COLUMN_TYPE,
-                            IS_NULLABLE
-                        )
-                    )
-                ) AS dbsignature,
-                1 AS grouper
-            FROM
-                information_schema.columns
-            WHERE
-                table_schema = DATABASE()
-            GROUP BY
-                grouper' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'dbsignature\'|\'grouper\'',
-              1 => 'int|string',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              1 => 'int<-2147483648, 2147483647>|string|null',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -2147483648,
-                 'max' => 2147483647,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-                2 => 'string|null',
-                3 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            1 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-                2 => 'string|null',
-                3 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
         3 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'dbsignature\'|\'grouper\'',
-              1 => 'string',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'dbsignature',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'grouper',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
            'itemType' => 
           PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              1 => 'int<-2147483648, 2147483647>|string|null',
-            ),
              'types' => 
             array (
               0 => 
               PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -2147483648,
-                 'max' => 2147483647,
+                 'min' => -32768,
+                 'max' => 32767,
               )),
               1 => 
               PHPStan\Type\StringType::__set_state(array(
               )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            1 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            2 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'dbsignature',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'grouper',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-                3 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
-    'SELECT column_name, column_default, is_nullable
-                FROM information_schema.columns
-                WHERE table_name = \'1970-01-01\'' => 
+    'SELECT email, adaid /* why? ? */ FROM ada /* just ?? :because ?*/ WHERE email = \'a\' -- ?' => 
     array (
       'result' => 
       array (
         5 => 
         PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
           PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
-              2 => '0|1|2|\'column_default\'|\'column_name\'|\'is_nullable\'',
-              1 => 'int|string',
+              2 => '0|1|\'adaid\'|\'email\'',
             ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada -- :can have :more ? :placeholders? ?' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada -- nice :placeholder bro' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE adaid = \'1\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
@@ -512,84 +767,53 @@
                  'value' => 2,
               )),
               3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'column_default',
-                   'isClassString' => false,
-                )),
-                 'value' => 'column_default',
-                 'isClassString' => false,
+              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
               )),
               4 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'column_name',
-                   'isClassString' => false,
-                )),
-                 'value' => 'column_name',
+                 'value' => 'adaid',
                  'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               5 => 
               PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'is_nullable',
-                   'isClassString' => false,
-                )),
-                 'value' => 'is_nullable',
+                 'value' => 'email',
                  'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
             ),
              'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
-              1 => 'string|null',
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-              1 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 3,
-          ),
            'keyTypes' => 
           array (
             0 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'column_name',
-                 'isClassString' => false,
-              )),
-               'value' => 'column_name',
+               'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
@@ -597,16 +821,10 @@
             )),
             2 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'column_default',
-                 'isClassString' => false,
-              )),
-               'value' => 'column_default',
+               'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
@@ -614,20 +832,25 @@
             )),
             4 => 
             PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'is_nullable',
-                 'isClassString' => false,
-              )),
-               'value' => 'is_nullable',
+               'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             5 => 
             PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
+            )),
+            6 => 
+            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            7 => 
+            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 3,
             )),
           ),
            'valueTypes' => 
@@ -639,54 +862,59 @@
             PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => true,
-               'cachedDescriptions' => 
-              array (
-                4 => 'string|null',
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\StringType::__set_state(array(
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
             )),
             5 => 
-            PHPStan\Type\StringType::__set_state(array(
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            6 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            7 => 
+            PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
             )),
           ),
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
+    ),
+    'Select * from ada
+            where adakzid = 15' => 
+    array (
+      'error' => 
+      staabm\PHPStanDba\Error::__set_state(array(
+         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'adakzid\' in \'where clause\'',
+         'code' => '42S22',
+      )),
     ),
   ),
   'runtimeConfig' => 

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -42,9 +42,9 @@ final class QueryReflection
     // see https://github.com/php/php-src/blob/01b3fc03c30c6cb85038250bb5640be3a09c6a32/ext/pdo/pdo_sql_parser.re#L48
     private const NAMED_PATTERN = ':[a-zA-Z0-9_]+';
 
-    private const REGEX_UNNAMED_PLACEHOLDER = '{(["\'])([^"\']*\1)|(' . self::UNNAMED_PATTERN . ')}';
+    private const REGEX_UNNAMED_PLACEHOLDER = '{(["\'])((?:(?!\1).)*\1)|(' . self::UNNAMED_PATTERN . ')}';
 
-    private const REGEX_NAMED_PLACEHOLDER = '{(["\'])([^"\']*\1)|(' . self::NAMED_PATTERN . ')}';
+    private const REGEX_NAMED_PLACEHOLDER = '{(["\'])((?:(?!\1).)*\1)|(' . self::NAMED_PATTERN . ')}';
 
     /**
      * @var QueryReflector|null

--- a/tests/rules/SyntaxErrorInQueryFunctionRuleTest.php
+++ b/tests/rules/SyntaxErrorInQueryFunctionRuleTest.php
@@ -115,6 +115,10 @@ TEXT
             self::markTestSkipped('Test requires PHP 8.2.');
         }
 
+        if (MysqliQueryReflector::NAME !== getenv('DBA_REFLECTOR')) {
+            self::markTestSkipped('mysqli test only.');
+        }
+
         $this->analyse([__DIR__ . '/data/mysqli_execute_query.php'], [
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",

--- a/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
+++ b/tests/rules/SyntaxErrorInQueryMethodRuleTest.php
@@ -292,6 +292,10 @@ LINE 1: EXPLAIN REPLACE into adasfd SET email="sdf"
             self::markTestSkipped('Test requires PHP 8.2.');
         }
 
+        if (MysqliQueryReflector::NAME !== getenv('DBA_REFLECTOR')) {
+            self::markTestSkipped('mysqli test only.');
+        }
+
         $this->analyse([__DIR__ . '/data/mysqli_execute_query.php'], [
             [
                 "Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near 'freigabe1u1 FROM ada LIMIT 0' at line 1 (1064).",

--- a/tests/rules/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/rules/config/.phpunit-phpstan-dba-mysqli.cache
@@ -3,193 +3,34 @@
   'schemaHash' => NULL,
   'records' => 
   array (
-    'DELETE from adasfd' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => 1146,
-      )),
-    ),
     'EXPLAIN DELETE from adasfd' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => 1146,
-      )),
-    ),
-    'EXPLAIN INSERT INTO `ada` SET email="test" WHERE adaid = 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'WHERE adaid = 1\' at line 1
-
-Simulated query: EXPLAIN INSERT INTO `ada` SET email="test" WHERE adaid = 1',
-         'code' => 1064,
       )),
     ),
     'EXPLAIN INSERT into adasfd SET email="sdf"' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => 1146,
-      )),
-    ),
-    'EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'WHERE adaid = 1\' at line 1
-
-Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
-         'code' => 1064,
       )),
     ),
     'EXPLAIN REPLACE into adasfd SET email="sdf"' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => 1146,
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada GROUP BY doesNotExist' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'doesNotExist\' in \'group statement\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada ORDER BY doesNotExist' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'doesNotExist\' in \'order clause\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada WHERE doesNotExist=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'doesNotExist\' in \'where clause\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT * FROM unknown_table' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.unknown_table\' doesn\'t exist',
-         'code' => 1146,
-      )),
-    ),
-    'EXPLAIN SELECT doesNotExist, adaid, gesperrt, freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'doesNotExist\' in \'field list\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT email adaid
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
-            FROM ada
-            LIMIT        1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 3',
-         'code' => 1064,
-      )),
-    ),
-    'EXPLAIN SELECT email adaid WHERE gesperrt FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'EXPLAIN SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'freigabe1u1 FROM ada\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'EXPLAIN SELECT email adaid gesperrt freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'gesperrt freigabe1u1 FROM ada\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid FROM ada GROUP BY xy LIMIT 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'xy\' in \'group statement\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid GROUP BY xy FROM ada  LIMIT 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=\'1\'' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'asdsa\' in \'where clause\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'asdsa\' in \'where clause\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND 1=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'does_not_exist\' in \'field list\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND email=\'test@example.com\'' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Unknown column \'does_not_exist\' in \'field list\'',
-         'code' => 1054,
-      )),
-    ),
-    'EXPLAIN SELECT with syntax error GROUPY by x' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'with syntax error GROUPY by x\' at line 1',
-         'code' => 1064,
       )),
     ),
     'EXPLAIN UPDATE adasfd SET email = ""' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => 1146,
       )),
@@ -197,68 +38,15 @@ Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
     'EXPLAIN UPDATE package SET indexedAt=\'1970-01-01\' WHERE id IN (NULL) AND (indexedAt IS NULL OR indexedAt <= crawledAt)' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.package\' doesn\'t exist',
-         'code' => 1146,
-      )),
-    ),
-    'INSERT IGNORE INTO `s_articles_supplier` (`id`, `name`, `img`, `link`, `changed`) VALUES (\'81729\', \'TestSupplier\', \'\', \'\', \'2019-12-09 10:42:10\');
-
-            INSERT INTO `s_articles` (`id`, `supplierID`, `name`, `datum`, `taxID`, `changetime`, `pricegroupID`, `pricegroupActive`, `filtergroupID`, `laststock`, `crossbundlelook`, `notification`, `template`, `mode`) VALUES
-            (\'91829002\', \'81729\', \'SwagTest\', \'2020-03-20\', \'1\', \'2020-03-20 10:42:10\', NULL, \'0\', NULL, \'0\', \'0\', \'0\', \'\', \'0\');
-
-            INSERT IGNORE INTO `s_order` (`id`, `ordernumber`, `userID`, `invoice_amount`, `invoice_amount_net`, `invoice_shipping`, `invoice_shipping_net`, `ordertime`, `status`, `cleared`, `paymentID`, `transactionID`, `comment`, `customercomment`, `internalcomment`, `net`, `taxfree`, `partnerID`, `temporaryID`, `referer`, `cleareddate`, `trackingcode`, `language`, `dispatchID`, `currency`, `currencyFactor`, `subshopID`, `remote_addr`) VALUES
-            (\'15315351\', \'29996\', 1, 126.82, 106.57, 3.9, 3.28, \'2013-07-10 08:17:20\', 0, 17, 5, \'\', \'\', \'\', \'\', 0, 0, \'\', \'\', \'\', NULL, \'\', \'1\', 9, \'EUR\', 1, 1, \'172.16.10.71\');
-
-            INSERT IGNORE INTO `s_order_details` (`id`, `orderID`, `ordernumber`, `articleID`, `articleordernumber`, `price`, `quantity`, `name`, `status`, `shipped`, `shippedgroup`, `releasedate`, `modus`, `esdarticle`, `taxID`, `tax_rate`, `config`) VALUES
-            (15315352, \'15315351\', \'20003\', \'91829002\', \'SW10178\', 19.95, 1, \'Strandtuch Ibiza\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315353, \'15315351\', \'20003\', 177, \'SW10177\', 34.99, 1, \'Strandtuch Stripes für Kinder\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315354, \'15315351\', \'20003\', 173, \'SW10173\', 39.99, 1, \'Strandkleid Flower Power\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315355, \'15315351\', \'20003\', 160, \'SW10160.1\', 29.99, 1, \'Sommer Sandale Ocean Blue 36\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315356, \'15315351\', \'20003\', 0, \'SHIPPINGDISCOUNT\', -2, 1, \'Warenkorbrabatt\', 0, 0, 0, \'0000-00-00\', 4, 0, 0, 19, \'\');' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'INSERT INTO `s_articles` (`id`, `supplierID`, `name`, `datum`, `taxID`, `chan...\' at line 3',
-         'code' => 1064,
-      )),
-    ),
-    'INSERT into %n' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'%n\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'INSERT into ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'\' at line 1',
-         'code' => 1064,
-      )),
-    ),
-    'INSERT into adasfd SET email="sdf"' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => 1146,
-      )),
-    ),
-    'REPLACE into adasfd SET email="sdf"' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => 1146,
       )),
     ),
     'SELECT * FROM  LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'LIMIT 0\' at line 1',
          'code' => 1064,
       )),
@@ -266,7 +54,7 @@ Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
     'SELECT * FROM 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'1 LIMIT 0\' at line 1
 
 Simulated query: SELECT * FROM 1 LIMIT 0',
@@ -276,504 +64,149 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
     'SELECT * FROM 1 LIMIT 1,1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'1 LIMIT 0\' at line 1
 
 Simulated query: SELECT * FROM 1 LIMIT 0',
          'code' => 1064,
       )),
     ),
-    'SELECT * FROM `ada` WHERE adaid = 1' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM `ada` WHERE email = \'test@example.com\';' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
     'SELECT * FROM ada' => 
     array (
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+              1 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            2 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'doesNotExist\' in \'group statement\'',
          'code' => 1054,
       )),
@@ -781,879 +214,166 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
     'SELECT * FROM ada ORDER BY doesNotExist' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'doesNotExist\' in \'order clause\'',
          'code' => 1054,
       )),
     ),
-    'SELECT * FROM ada WHERE adaid = \'1\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
     'SELECT * FROM ada WHERE doesNotExist=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'doesNotExist\' in \'where clause\'',
          'code' => 1054,
       )),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'  LIMIT \'27\' OFFSET \'15\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'  LIMIT 5 OFFSET 2' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
     ),
     'SELECT * FROM ak' => 
     array (
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -2147483648,
+                 'max' => 2147483647,
+              )),
+              1 => 
+              \PHPStan\Type\IntersectionType::__set_state(array(
+                 'types' => 
+                array (
+                  0 => 
+                  \PHPStan\Type\StringType::__set_state(array(
+                  )),
+                  1 => 
+                  \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                  )),
+                ),
+                 'sortedTypes' => false,
+              )),
+              2 => 
+              \PHPStan\Type\NullType::__set_state(array(
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'akid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'eadavk',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'eladaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '\'akid\'|\'eadavk\'|\'eladaid\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'akid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'eadavk',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'eladaid',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -2147483648,
-                 'max' => 2147483647,
-              )),
-              1 => 
-              PHPStan\Type\IntersectionType::__set_state(array(
-                 'sortedTypes' => false,
-                 'types' => 
-                array (
-                  0 => 
-                  PHPStan\Type\StringType::__set_state(array(
-                  )),
-                  1 => 
-                  PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                  )),
-                ),
-              )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'akid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'eladaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'eadavk',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -2147483648,
+               'max' => 2147483647,
+            )),
+            1 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => -2147483648,
+                   'max' => 2147483647,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            2 => 
+            \PHPStan\Type\IntersectionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                )),
+              ),
+               'sortedTypes' => false,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'akid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'eladaid',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'eadavk',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-            1 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerRangeType::__set_state(array(
-                   'min' => -2147483648,
-                   'max' => 2147483647,
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            2 => 
-            PHPStan\Type\IntersectionType::__set_state(array(
-               'sortedTypes' => false,
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                )),
-              ),
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -1662,1188 +382,1022 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'c_bigint\'|\'c_bit\'|\'c_blob\'|\'c_boolean\'|\'c_char5\'|\'c_date\'|\'c_datetime\'|\'c_decimal\'|\'c_decimal_not_null\'|\'c_double\'|\'c_enum\'|\'c_float\'|\'c_int\'|\'c_json\'|\'c_json_not_null\'|\'c_long_text\'|\'c_longblob\'|\'c_medium_text\'|\'c_mediumblog\'|\'c_mediumint\'|\'c_real\'|\'c_set\'|\'c_smallint\'|\'c_text\'|\'c_time\'|\'c_timestamp\'|\'c_tiny_text\'|\'c_tinyblob\'|\'c_tinyint\'|\'c_unsigned_bigint\'|\'c_unsigned_int\'|\'c_unsigned_mediumint\'|\'c_unsigned_smallint\'|\'c_unsigned_tinyint\'|\'c_varbinary25\'|\'c_varbinary255\'|\'c_varchar25\'|\'c_varchar255\'|\'c_year\'|\'pid\'',
-            ),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_bigint',
-                 'isClassString' => false,
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_bit',
-                 'isClassString' => false,
+              \PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_blob',
-                 'isClassString' => false,
+              \PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_boolean',
-                 'isClassString' => false,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_char5',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_date',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_datetime',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_decimal',
-                 'isClassString' => false,
-              )),
-              8 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_decimal_not_null',
-                 'isClassString' => false,
-              )),
-              9 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_double',
-                 'isClassString' => false,
-              )),
-              10 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_enum',
-                 'isClassString' => false,
-              )),
-              11 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_float',
-                 'isClassString' => false,
-              )),
-              12 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_int',
-                 'isClassString' => false,
-              )),
-              13 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_json',
-                 'isClassString' => false,
-              )),
-              14 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_json_not_null',
-                 'isClassString' => false,
-              )),
-              15 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_long_text',
-                 'isClassString' => false,
-              )),
-              16 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_longblob',
-                 'isClassString' => false,
-              )),
-              17 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_medium_text',
-                 'isClassString' => false,
-              )),
-              18 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_mediumblog',
-                 'isClassString' => false,
-              )),
-              19 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_mediumint',
-                 'isClassString' => false,
-              )),
-              20 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_real',
-                 'isClassString' => false,
-              )),
-              21 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_set',
-                 'isClassString' => false,
-              )),
-              22 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_smallint',
-                 'isClassString' => false,
-              )),
-              23 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_text',
-                 'isClassString' => false,
-              )),
-              24 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_time',
-                 'isClassString' => false,
-              )),
-              25 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_timestamp',
-                 'isClassString' => false,
-              )),
-              26 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tiny_text',
-                 'isClassString' => false,
-              )),
-              27 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tinyblob',
-                 'isClassString' => false,
-              )),
-              28 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tinyint',
-                 'isClassString' => false,
-              )),
-              29 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_bigint',
-                 'isClassString' => false,
-              )),
-              30 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_int',
-                 'isClassString' => false,
-              )),
-              31 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_mediumint',
-                 'isClassString' => false,
-              )),
-              32 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_smallint',
-                 'isClassString' => false,
-              )),
-              33 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_tinyint',
-                 'isClassString' => false,
-              )),
-              34 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varbinary25',
-                 'isClassString' => false,
-              )),
-              35 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varbinary255',
-                 'isClassString' => false,
-              )),
-              36 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varchar25',
-                 'isClassString' => false,
-              )),
-              37 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varchar255',
-                 'isClassString' => false,
-              )),
-              38 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_year',
-                 'isClassString' => false,
-              )),
-              39 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'pid',
-                 'isClassString' => false,
+              \PHPStan\Type\NullType::__set_state(array(
               )),
             ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+             'normalized' => true,
              'sortedTypes' => false,
              'cachedDescriptions' => 
             array (
             ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_bigint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               1 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_bit',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               2 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_blob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               3 => 
-              PHPStan\Type\NullType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_boolean',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_char5',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_date',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_datetime',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_decimal',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              8 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_decimal_not_null',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              9 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_double',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              10 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_enum',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              11 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_float',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              12 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_int',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              13 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_json',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              14 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_json_not_null',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              15 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_long_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              16 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_longblob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              17 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_medium_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              18 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_mediumblog',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              19 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_mediumint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              20 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_nullable_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              21 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_real',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              22 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_set',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              23 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_smallint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              24 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              25 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_time',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              26 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_timestamp',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              27 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tiny_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              28 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tinyblob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              29 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              30 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_bigint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              31 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_int',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              32 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_mediumint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              33 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_smallint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              34 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              35 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varbinary25',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              36 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varbinary255',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              37 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varchar25',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              38 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varchar255',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              39 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_year',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              40 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'pid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
             ),
-             'normalized' => true,
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'c_bigint\'|\'c_bit\'|\'c_blob\'|\'c_boolean\'|\'c_char5\'|\'c_date\'|\'c_datetime\'|\'c_decimal\'|\'c_decimal_not_null\'|\'c_double\'|\'c_enum\'|\'c_float\'|\'c_int\'|\'c_json\'|\'c_json_not_null\'|\'c_long_text\'|\'c_longblob\'|\'c_medium_text\'|\'c_mediumblog\'|\'c_mediumint\'|\'c_nullable_tinyint\'|\'c_real\'|\'c_set\'|\'c_smallint\'|\'c_text\'|\'c_time\'|\'c_timestamp\'|\'c_tiny_text\'|\'c_tinyblob\'|\'c_tinyint\'|\'c_unsigned_bigint\'|\'c_unsigned_int\'|\'c_unsigned_mediumint\'|\'c_unsigned_smallint\'|\'c_unsigned_tinyint\'|\'c_varbinary25\'|\'c_varbinary255\'|\'c_varchar25\'|\'c_varchar255\'|\'c_year\'|\'pid\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'pid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_char5',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varchar255',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varchar25',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            4 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varbinary255',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            5 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varbinary25',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            6 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_date',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            7 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_time',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            8 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_datetime',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            9 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_timestamp',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            10 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_year',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            11 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tiny_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            12 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_medium_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            13 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            14 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_long_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            15 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_enum',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            16 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_set',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            17 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_bit',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            18 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_int',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            19 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            20 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_nullable_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            21 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_smallint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            22 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_mediumint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            23 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_bigint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            24 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_double',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            25 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_real',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            26 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_float',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            27 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_boolean',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            28 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_blob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            29 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tinyblob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            30 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_mediumblog',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            31 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_longblob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            32 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            33 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_int',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            34 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_smallint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            35 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_mediumint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            36 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_bigint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            37 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_json',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            38 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_json_not_null',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            39 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_decimal',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            40 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_decimal_not_null',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            4 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            5 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            6 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            7 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            8 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            9 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            10 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => 0,
+                   'max' => 2155,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            11 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            12 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            13 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            14 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            15 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            16 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            17 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            18 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -2147483648,
+               'max' => 2147483647,
+            )),
+            19 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            20 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => -128,
+                   'max' => 127,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            21 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            22 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -8388608,
+               'max' => 8388607,
+            )),
+            23 => 
+            \PHPStan\Type\IntegerType::__set_state(array(
+            )),
+            24 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            25 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            26 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            27 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            28 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            29 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            30 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            31 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            32 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 255,
+            )),
+            33 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            34 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 65535,
+            )),
+            35 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 16777215,
+            )),
+            36 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => NULL,
+            )),
+            37 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            38 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            39 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntersectionType::__set_state(array(
+                   'types' => 
+                  array (
+                    0 => 
+                    \PHPStan\Type\StringType::__set_state(array(
+                    )),
+                    1 => 
+                    \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                    )),
+                  ),
+                   'sortedTypes' => true,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            40 => 
+            \PHPStan\Type\IntersectionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                )),
+              ),
+               'sortedTypes' => true,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'pid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_char5',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varchar255',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varchar25',
-               'isClassString' => false,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varbinary255',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varbinary25',
-               'isClassString' => false,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_date',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_time',
-               'isClassString' => false,
-            )),
-            8 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_datetime',
-               'isClassString' => false,
-            )),
-            9 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_timestamp',
-               'isClassString' => false,
-            )),
-            10 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_year',
-               'isClassString' => false,
-            )),
-            11 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tiny_text',
-               'isClassString' => false,
-            )),
-            12 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_medium_text',
-               'isClassString' => false,
-            )),
-            13 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_text',
-               'isClassString' => false,
-            )),
-            14 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_long_text',
-               'isClassString' => false,
-            )),
-            15 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_enum',
-               'isClassString' => false,
-            )),
-            16 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_set',
-               'isClassString' => false,
-            )),
-            17 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_bit',
-               'isClassString' => false,
-            )),
-            18 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_int',
-               'isClassString' => false,
-            )),
-            19 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tinyint',
-               'isClassString' => false,
-            )),
-            20 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_smallint',
-               'isClassString' => false,
-            )),
-            21 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_mediumint',
-               'isClassString' => false,
-            )),
-            22 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_bigint',
-               'isClassString' => false,
-            )),
-            23 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_double',
-               'isClassString' => false,
-            )),
-            24 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_real',
-               'isClassString' => false,
-            )),
-            25 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_float',
-               'isClassString' => false,
-            )),
-            26 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_boolean',
-               'isClassString' => false,
-            )),
-            27 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_blob',
-               'isClassString' => false,
-            )),
-            28 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tinyblob',
-               'isClassString' => false,
-            )),
-            29 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_mediumblog',
-               'isClassString' => false,
-            )),
-            30 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_longblob',
-               'isClassString' => false,
-            )),
-            31 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_tinyint',
-               'isClassString' => false,
-            )),
-            32 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_int',
-               'isClassString' => false,
-            )),
-            33 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_smallint',
-               'isClassString' => false,
-            )),
-            34 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_mediumint',
-               'isClassString' => false,
-            )),
-            35 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_bigint',
-               'isClassString' => false,
-            )),
-            36 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_json',
-               'isClassString' => false,
-            )),
-            37 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_json_not_null',
-               'isClassString' => false,
-            )),
-            38 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_decimal',
-               'isClassString' => false,
-            )),
-            39 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_decimal_not_null',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            1 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            6 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            7 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            8 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            9 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            10 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerRangeType::__set_state(array(
-                   'min' => 0,
-                   'max' => 2155,
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            11 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            12 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            13 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            14 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            15 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            16 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            17 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            18 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-            19 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            20 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            21 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -8388608,
-               'max' => 8388607,
-            )),
-            22 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-            23 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            24 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            25 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            26 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            27 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            28 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            29 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            30 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            31 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 255,
-            )),
-            32 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            33 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 65535,
-            )),
-            34 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 16777215,
-            )),
-            35 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => NULL,
-            )),
-            36 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            37 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            38 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntersectionType::__set_state(array(
-                   'sortedTypes' => true,
-                   'types' => 
-                  array (
-                    0 => 
-                    PHPStan\Type\StringType::__set_state(array(
-                    )),
-                    1 => 
-                    PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                    )),
-                  ),
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            39 => 
-            PHPStan\Type\IntersectionType::__set_state(array(
-               'sortedTypes' => true,
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                )),
-              ),
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT * FROM unknown_table' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Table \'phpstan_dba.unknown_table\' doesn\'t exist',
          'code' => 1146,
-      )),
-    ),
-    'SELECT *,adaid FROM `ada` WHERE email = \'test@example.com\';' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|4|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 4,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              8 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 5,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-            8 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 4,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            8 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT FROM WHERE' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM WHERE LIMIT 0\' at line 1
-
-Simulated query: SELECT FROM WHERE LIMIT 0',
-         'code' => 1064,
       )),
     ),
     'SELECT adaid FROM ada WHERE email=\'1970-01-01\'' => 
@@ -2851,63 +1405,58 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\IntegerRangeType::__set_state(array(
+             'min' => -32768,
+             'max' => 32767,
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '0|\'adaid\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\IntegerRangeType::__set_state(array(
-             'min' => -32768,
-             'max' => 32767,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 1,
-          ),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -2915,14 +1464,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 1,
+          ),
         )),
       ),
     ),
     'SELECT doesNotExist, adaid, gesperrt, freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'doesNotExist\' in \'field list\'',
          'code' => 1054,
       )),
@@ -2932,103 +1489,109 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '0|\'email\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 1,
-          ),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
           ),
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 1,
+          ),
         )),
       ),
     ),
@@ -3037,42 +1600,45 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -3081,42 +1647,45 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -3126,7 +1695,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
             LIMIT        1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
          'code' => 1064,
       )),
@@ -3134,7 +1703,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid WHERE gesperrt FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 1',
          'code' => 1064,
       )),
@@ -3142,7 +1711,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'freigabe1u1 FROM ada LIMIT 0\' at line 1',
          'code' => 1064,
       )),
@@ -3150,7 +1719,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid gesperrt freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'gesperrt freigabe1u1 FROM ada LIMIT 0\' at line 1',
          'code' => 1064,
       )),
@@ -3160,105 +1729,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3266,7 +1830,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3275,129 +1847,124 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3405,7 +1972,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3414,105 +1989,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3520,7 +2090,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3529,105 +2107,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3635,14 +2208,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid FROM ada GROUP BY xy LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'xy\' in \'group statement\'',
          'code' => 1054,
       )),
@@ -3652,105 +2233,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3758,7 +2334,369 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' OR adaid = \'10\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' OR adaid = \'10\' and email = \'hello world\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' and email = \'hello world\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3767,129 +2705,124 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3897,14 +2830,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid GROUP BY xy FROM ada  LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 1',
          'code' => 1064,
       )),
@@ -3914,340 +2855,338 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4255,7 +3194,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4264,217 +3211,212 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4482,7 +3424,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4491,217 +3441,212 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4709,7 +3654,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4718,169 +3671,164 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4888,14 +3836,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=\'1\'' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'asdsa\' in \'where clause\'',
          'code' => 1054,
       )),
@@ -4903,7 +3859,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'asdsa\' in \'where clause\'',
          'code' => 1054,
       )),
@@ -4913,169 +3869,164 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -5083,14 +4034,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
     'SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND 1=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'does_not_exist\' in \'field list\'',
          'code' => 1054,
       )),
@@ -5098,7 +4057,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND email=\'test@example.com\'' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'Unknown column \'does_not_exist\' in \'field list\'',
          'code' => 1054,
       )),
@@ -5108,105 +4067,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -5214,117 +4168,112 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT with syntax error GROUPY by x' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'with syntax error GROUPY by x LIMIT 0\' at line 1',
          'code' => 1064,
-      )),
-    ),
-    'UPDATE adasfd SET email = ""' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => 1146,
-      )),
-    ),
-    'UPDATE package SET indexedAt=\'1970-01-01\' WHERE id IN (NULL) AND (indexedAt IS NULL OR indexedAt <= crawledAt)' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'Table \'phpstan_dba.package\' doesn\'t exist',
-         'code' => 1146,
       )),
     ),
   ),

--- a/tests/rules/config/.phpunit-phpstan-dba-pdo-mysql.cache
+++ b/tests/rules/config/.phpunit-phpstan-dba-pdo-mysql.cache
@@ -3,18 +3,10 @@
   'schemaHash' => NULL,
   'records' => 
   array (
-    'DELETE from adasfd' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
     'EXPLAIN DELETE from adasfd' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => '42S02',
       )),
@@ -35,182 +27,31 @@
             (15315356, \'15315351\', \'20003\', 0, \'SHIPPINGDISCOUNT\', -2, 1, \'Warenkorbrabatt\', 0, 0, 0, \'0000-00-00\', 4, 0, 0, 19, \'\');' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.s_articles_supplier\' doesn\'t exist',
          'code' => '42S02',
-      )),
-    ),
-    'EXPLAIN INSERT INTO `ada` SET email="test" WHERE adaid = 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'WHERE adaid = 1\' at line 1
-
-Simulated query: EXPLAIN INSERT INTO `ada` SET email="test" WHERE adaid = 1',
-         'code' => '42000',
       )),
     ),
     'EXPLAIN INSERT into adasfd SET email="sdf"' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => '42S02',
-      )),
-    ),
-    'EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'WHERE adaid = 1\' at line 1
-
-Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
-         'code' => '42000',
       )),
     ),
     'EXPLAIN REPLACE into adasfd SET email="sdf"' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => '42S02',
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada GROUP BY doesNotExist' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'group statement\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada ORDER BY doesNotExist' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'order clause\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT * FROM ada WHERE doesNotExist=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'where clause\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT * FROM unknown_table' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.unknown_table\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
-    'EXPLAIN SELECT doesNotExist, adaid, gesperrt, freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'field list\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT email adaid
-            WHERE gesperrt = \'1\' AND email LIKE \'%@example.com\'
-            FROM ada
-            LIMIT        1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 3',
-         'code' => '42000',
-      )),
-    ),
-    'EXPLAIN SELECT email adaid WHERE gesperrt FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 1',
-         'code' => '42000',
-      )),
-    ),
-    'EXPLAIN SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'freigabe1u1 FROM ada\' at line 1',
-         'code' => '42000',
-      )),
-    ),
-    'EXPLAIN SELECT email adaid gesperrt freigabe1u1 FROM ada' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'gesperrt freigabe1u1 FROM ada\' at line 1',
-         'code' => '42000',
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid FROM ada GROUP BY xy LIMIT 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'xy\' in \'group statement\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid GROUP BY xy FROM ada  LIMIT 1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada\' at line 1',
-         'code' => '42000',
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=\'1\'' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'asdsa\' in \'where clause\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'asdsa\' in \'where clause\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND 1=1' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'does_not_exist\' in \'field list\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND email=\'test@example.com\'' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'does_not_exist\' in \'field list\'',
-         'code' => '42S22',
-      )),
-    ),
-    'EXPLAIN SELECT with syntax error GROUPY by x' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'with syntax error GROUPY by x\' at line 1',
-         'code' => '42000',
       )),
     ),
     'EXPLAIN UPDATE adasfd SET email = ""' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => '42S02',
       )),
@@ -218,52 +59,15 @@ Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
     'EXPLAIN UPDATE package SET indexedAt=\'1970-01-01\' WHERE id IN (NULL) AND (indexedAt IS NULL OR indexedAt <= crawledAt)' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.package\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
-    'INSERT IGNORE INTO `s_articles_supplier` (`id`, `name`, `img`, `link`, `changed`) VALUES (\'81729\', \'TestSupplier\', \'\', \'\', \'2019-12-09 10:42:10\');
-
-            INSERT INTO `s_articles` (`id`, `supplierID`, `name`, `datum`, `taxID`, `changetime`, `pricegroupID`, `pricegroupActive`, `filtergroupID`, `laststock`, `crossbundlelook`, `notification`, `template`, `mode`) VALUES
-            (\'91829002\', \'81729\', \'SwagTest\', \'2020-03-20\', \'1\', \'2020-03-20 10:42:10\', NULL, \'0\', NULL, \'0\', \'0\', \'0\', \'\', \'0\');
-
-            INSERT IGNORE INTO `s_order` (`id`, `ordernumber`, `userID`, `invoice_amount`, `invoice_amount_net`, `invoice_shipping`, `invoice_shipping_net`, `ordertime`, `status`, `cleared`, `paymentID`, `transactionID`, `comment`, `customercomment`, `internalcomment`, `net`, `taxfree`, `partnerID`, `temporaryID`, `referer`, `cleareddate`, `trackingcode`, `language`, `dispatchID`, `currency`, `currencyFactor`, `subshopID`, `remote_addr`) VALUES
-            (\'15315351\', \'29996\', 1, 126.82, 106.57, 3.9, 3.28, \'2013-07-10 08:17:20\', 0, 17, 5, \'\', \'\', \'\', \'\', 0, 0, \'\', \'\', \'\', NULL, \'\', \'1\', 9, \'EUR\', 1, 1, \'172.16.10.71\');
-
-            INSERT IGNORE INTO `s_order_details` (`id`, `orderID`, `ordernumber`, `articleID`, `articleordernumber`, `price`, `quantity`, `name`, `status`, `shipped`, `shippedgroup`, `releasedate`, `modus`, `esdarticle`, `taxID`, `tax_rate`, `config`) VALUES
-            (15315352, \'15315351\', \'20003\', \'91829002\', \'SW10178\', 19.95, 1, \'Strandtuch Ibiza\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315353, \'15315351\', \'20003\', 177, \'SW10177\', 34.99, 1, \'Strandtuch Stripes für Kinder\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315354, \'15315351\', \'20003\', 173, \'SW10173\', 39.99, 1, \'Strandkleid Flower Power\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315355, \'15315351\', \'20003\', 160, \'SW10160.1\', 29.99, 1, \'Sommer Sandale Ocean Blue 36\', 0, 0, 0, \'0000-00-00\', 0, 0, 1, 19, \'\'),
-            (15315356, \'15315351\', \'20003\', 0, \'SHIPPINGDISCOUNT\', -2, 1, \'Warenkorbrabatt\', 0, 0, 0, \'0000-00-00\', 4, 0, 0, 19, \'\');' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.s_articles_supplier\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
-    'INSERT into adasfd SET email="sdf"' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
-    'REPLACE into adasfd SET email="sdf"' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
          'code' => '42S02',
       )),
     ),
     'SELECT * FROM  LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'LIMIT 0\' at line 1',
          'code' => '42000',
       )),
@@ -271,7 +75,7 @@ Simulated query: EXPLAIN REPLACE INTO `ada` SET email="test" WHERE adaid = 1',
     'SELECT * FROM 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'1 LIMIT 0\' at line 1
 
 Simulated query: SELECT * FROM 1 LIMIT 0',
@@ -281,504 +85,149 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
     'SELECT * FROM 1 LIMIT 1,1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'1 LIMIT 0\' at line 1
 
 Simulated query: SELECT * FROM 1 LIMIT 0',
          'code' => '42000',
       )),
     ),
-    'SELECT * FROM `ada` WHERE adaid = 1' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM `ada` WHERE email = \'test@example.com\';' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
     'SELECT * FROM ada' => 
     array (
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+              1 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            2 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT * FROM ada GROUP BY doesNotExist' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'group statement\'',
          'code' => '42S22',
       )),
@@ -786,879 +235,166 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
     'SELECT * FROM ada ORDER BY doesNotExist' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'order clause\'',
          'code' => '42S22',
       )),
     ),
-    'SELECT * FROM ada WHERE adaid = \'1\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
     'SELECT * FROM ada WHERE doesNotExist=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'where clause\'',
          'code' => '42S22',
       )),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'  LIMIT \'27\' OFFSET \'15\'' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT * FROM ada WHERE email = \'1970-01-01\'  LIMIT 5 OFFSET 2' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
     ),
     'SELECT * FROM ak' => 
     array (
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -2147483648,
+                 'max' => 2147483647,
+              )),
+              1 => 
+              \PHPStan\Type\IntersectionType::__set_state(array(
+                 'types' => 
+                array (
+                  0 => 
+                  \PHPStan\Type\StringType::__set_state(array(
+                  )),
+                  1 => 
+                  \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                  )),
+                ),
+                 'sortedTypes' => false,
+              )),
+              2 => 
+              \PHPStan\Type\NullType::__set_state(array(
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'akid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'eadavk',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'eladaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '\'akid\'|\'eadavk\'|\'eladaid\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'akid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'eadavk',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'eladaid',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -2147483648,
-                 'max' => 2147483647,
-              )),
-              1 => 
-              PHPStan\Type\IntersectionType::__set_state(array(
-                 'sortedTypes' => false,
-                 'types' => 
-                array (
-                  0 => 
-                  PHPStan\Type\StringType::__set_state(array(
-                  )),
-                  1 => 
-                  PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                  )),
-                ),
-              )),
-              2 => 
-              PHPStan\Type\NullType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'akid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'eladaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'eadavk',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -2147483648,
+               'max' => 2147483647,
+            )),
+            1 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => -2147483648,
+                   'max' => 2147483647,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            2 => 
+            \PHPStan\Type\IntersectionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                )),
+              ),
+               'sortedTypes' => false,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'akid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'eladaid',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'eadavk',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-            1 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerRangeType::__set_state(array(
-                   'min' => -2147483648,
-                   'max' => 2147483647,
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            2 => 
-            PHPStan\Type\IntersectionType::__set_state(array(
-               'sortedTypes' => false,
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                )),
-              ),
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -1667,1188 +403,1022 @@ Simulated query: SELECT * FROM 1 LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'c_bigint\'|\'c_bit\'|\'c_blob\'|\'c_boolean\'|\'c_char5\'|\'c_date\'|\'c_datetime\'|\'c_decimal\'|\'c_decimal_not_null\'|\'c_double\'|\'c_enum\'|\'c_float\'|\'c_int\'|\'c_json\'|\'c_json_not_null\'|\'c_long_text\'|\'c_longblob\'|\'c_medium_text\'|\'c_mediumblog\'|\'c_mediumint\'|\'c_real\'|\'c_set\'|\'c_smallint\'|\'c_text\'|\'c_time\'|\'c_timestamp\'|\'c_tiny_text\'|\'c_tinyblob\'|\'c_tinyint\'|\'c_unsigned_bigint\'|\'c_unsigned_int\'|\'c_unsigned_mediumint\'|\'c_unsigned_smallint\'|\'c_unsigned_tinyint\'|\'c_varbinary25\'|\'c_varbinary255\'|\'c_varchar25\'|\'c_varchar255\'|\'c_year\'|\'pid\'',
-            ),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_bigint',
-                 'isClassString' => false,
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_bit',
-                 'isClassString' => false,
+              \PHPStan\Type\FloatType::__set_state(array(
               )),
               2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_blob',
-                 'isClassString' => false,
+              \PHPStan\Type\IntegerType::__set_state(array(
               )),
               3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_boolean',
-                 'isClassString' => false,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_char5',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_date',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_datetime',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_decimal',
-                 'isClassString' => false,
-              )),
-              8 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_decimal_not_null',
-                 'isClassString' => false,
-              )),
-              9 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_double',
-                 'isClassString' => false,
-              )),
-              10 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_enum',
-                 'isClassString' => false,
-              )),
-              11 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_float',
-                 'isClassString' => false,
-              )),
-              12 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_int',
-                 'isClassString' => false,
-              )),
-              13 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_json',
-                 'isClassString' => false,
-              )),
-              14 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_json_not_null',
-                 'isClassString' => false,
-              )),
-              15 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_long_text',
-                 'isClassString' => false,
-              )),
-              16 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_longblob',
-                 'isClassString' => false,
-              )),
-              17 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_medium_text',
-                 'isClassString' => false,
-              )),
-              18 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_mediumblog',
-                 'isClassString' => false,
-              )),
-              19 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_mediumint',
-                 'isClassString' => false,
-              )),
-              20 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_real',
-                 'isClassString' => false,
-              )),
-              21 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_set',
-                 'isClassString' => false,
-              )),
-              22 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_smallint',
-                 'isClassString' => false,
-              )),
-              23 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_text',
-                 'isClassString' => false,
-              )),
-              24 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_time',
-                 'isClassString' => false,
-              )),
-              25 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_timestamp',
-                 'isClassString' => false,
-              )),
-              26 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tiny_text',
-                 'isClassString' => false,
-              )),
-              27 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tinyblob',
-                 'isClassString' => false,
-              )),
-              28 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_tinyint',
-                 'isClassString' => false,
-              )),
-              29 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_bigint',
-                 'isClassString' => false,
-              )),
-              30 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_int',
-                 'isClassString' => false,
-              )),
-              31 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_mediumint',
-                 'isClassString' => false,
-              )),
-              32 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_smallint',
-                 'isClassString' => false,
-              )),
-              33 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_unsigned_tinyint',
-                 'isClassString' => false,
-              )),
-              34 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varbinary25',
-                 'isClassString' => false,
-              )),
-              35 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varbinary255',
-                 'isClassString' => false,
-              )),
-              36 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varchar25',
-                 'isClassString' => false,
-              )),
-              37 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_varchar255',
-                 'isClassString' => false,
-              )),
-              38 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'c_year',
-                 'isClassString' => false,
-              )),
-              39 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'pid',
-                 'isClassString' => false,
+              \PHPStan\Type\NullType::__set_state(array(
               )),
             ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+             'normalized' => true,
              'sortedTypes' => false,
              'cachedDescriptions' => 
             array (
             ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_bigint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               1 => 
-              PHPStan\Type\FloatType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_bit',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               2 => 
-              PHPStan\Type\IntegerType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_blob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
               3 => 
-              PHPStan\Type\NullType::__set_state(array(
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_boolean',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_char5',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_date',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_datetime',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_decimal',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              8 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_decimal_not_null',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              9 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_double',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              10 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_enum',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              11 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_float',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              12 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_int',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              13 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_json',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              14 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_json_not_null',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              15 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_long_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              16 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_longblob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              17 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_medium_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              18 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_mediumblog',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              19 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_mediumint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              20 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_nullable_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              21 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_real',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              22 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_set',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              23 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_smallint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              24 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              25 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_time',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              26 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_timestamp',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              27 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tiny_text',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              28 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tinyblob',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              29 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              30 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_bigint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              31 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_int',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              32 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_mediumint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              33 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_smallint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              34 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_unsigned_tinyint',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              35 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varbinary25',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              36 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varbinary255',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              37 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varchar25',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              38 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_varchar255',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              39 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'c_year',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              40 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'pid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
               )),
             ),
-             'normalized' => true,
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'c_bigint\'|\'c_bit\'|\'c_blob\'|\'c_boolean\'|\'c_char5\'|\'c_date\'|\'c_datetime\'|\'c_decimal\'|\'c_decimal_not_null\'|\'c_double\'|\'c_enum\'|\'c_float\'|\'c_int\'|\'c_json\'|\'c_json_not_null\'|\'c_long_text\'|\'c_longblob\'|\'c_medium_text\'|\'c_mediumblog\'|\'c_mediumint\'|\'c_nullable_tinyint\'|\'c_real\'|\'c_set\'|\'c_smallint\'|\'c_text\'|\'c_time\'|\'c_timestamp\'|\'c_tiny_text\'|\'c_tinyblob\'|\'c_tinyint\'|\'c_unsigned_bigint\'|\'c_unsigned_int\'|\'c_unsigned_mediumint\'|\'c_unsigned_smallint\'|\'c_unsigned_tinyint\'|\'c_varbinary25\'|\'c_varbinary255\'|\'c_varchar25\'|\'c_varchar255\'|\'c_year\'|\'pid\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'pid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_char5',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varchar255',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varchar25',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            4 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varbinary255',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            5 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_varbinary25',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            6 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_date',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            7 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_time',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            8 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_datetime',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            9 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_timestamp',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            10 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_year',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            11 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tiny_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            12 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_medium_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            13 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            14 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_long_text',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            15 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_enum',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            16 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_set',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            17 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_bit',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            18 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_int',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            19 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            20 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_nullable_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            21 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_smallint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            22 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_mediumint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            23 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_bigint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            24 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_double',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            25 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_real',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            26 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_float',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            27 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_boolean',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            28 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_blob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            29 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_tinyblob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            30 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_mediumblog',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            31 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_longblob',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            32 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_tinyint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            33 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_int',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            34 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_smallint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            35 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_mediumint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            36 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_unsigned_bigint',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            37 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_json',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            38 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_json_not_null',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            39 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_decimal',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            40 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'c_decimal_not_null',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            3 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            4 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            5 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            6 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            7 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            8 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            9 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            10 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => 0,
+                   'max' => 2155,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            11 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            12 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            13 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            14 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            15 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            16 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            17 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            18 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -2147483648,
+               'max' => 2147483647,
+            )),
+            19 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            20 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntegerRangeType::__set_state(array(
+                   'min' => -128,
+                   'max' => 127,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            21 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            22 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -8388608,
+               'max' => 8388607,
+            )),
+            23 => 
+            \PHPStan\Type\IntegerType::__set_state(array(
+            )),
+            24 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            25 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            26 => 
+            \PHPStan\Type\FloatType::__set_state(array(
+            )),
+            27 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            28 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            29 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            30 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            31 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            32 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 255,
+            )),
+            33 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 4294967295,
+            )),
+            34 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 65535,
+            )),
+            35 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => 16777215,
+            )),
+            36 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => 0,
+               'max' => NULL,
+            )),
+            37 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            38 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            39 => 
+            \PHPStan\Type\UnionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\IntersectionType::__set_state(array(
+                   'types' => 
+                  array (
+                    0 => 
+                    \PHPStan\Type\StringType::__set_state(array(
+                    )),
+                    1 => 
+                    \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                    )),
+                  ),
+                   'sortedTypes' => true,
+                )),
+                1 => 
+                \PHPStan\Type\NullType::__set_state(array(
+                )),
+              ),
+               'normalized' => true,
+               'sortedTypes' => false,
+               'cachedDescriptions' => 
+              array (
+              ),
+            )),
+            40 => 
+            \PHPStan\Type\IntersectionType::__set_state(array(
+               'types' => 
+              array (
+                0 => 
+                \PHPStan\Type\StringType::__set_state(array(
+                )),
+                1 => 
+                \PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
+                )),
+              ),
+               'sortedTypes' => true,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'pid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_char5',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varchar255',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varchar25',
-               'isClassString' => false,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varbinary255',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_varbinary25',
-               'isClassString' => false,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_date',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_time',
-               'isClassString' => false,
-            )),
-            8 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_datetime',
-               'isClassString' => false,
-            )),
-            9 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_timestamp',
-               'isClassString' => false,
-            )),
-            10 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_year',
-               'isClassString' => false,
-            )),
-            11 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tiny_text',
-               'isClassString' => false,
-            )),
-            12 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_medium_text',
-               'isClassString' => false,
-            )),
-            13 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_text',
-               'isClassString' => false,
-            )),
-            14 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_long_text',
-               'isClassString' => false,
-            )),
-            15 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_enum',
-               'isClassString' => false,
-            )),
-            16 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_set',
-               'isClassString' => false,
-            )),
-            17 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_bit',
-               'isClassString' => false,
-            )),
-            18 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_int',
-               'isClassString' => false,
-            )),
-            19 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tinyint',
-               'isClassString' => false,
-            )),
-            20 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_smallint',
-               'isClassString' => false,
-            )),
-            21 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_mediumint',
-               'isClassString' => false,
-            )),
-            22 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_bigint',
-               'isClassString' => false,
-            )),
-            23 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_double',
-               'isClassString' => false,
-            )),
-            24 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_real',
-               'isClassString' => false,
-            )),
-            25 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_float',
-               'isClassString' => false,
-            )),
-            26 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_boolean',
-               'isClassString' => false,
-            )),
-            27 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_blob',
-               'isClassString' => false,
-            )),
-            28 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_tinyblob',
-               'isClassString' => false,
-            )),
-            29 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_mediumblog',
-               'isClassString' => false,
-            )),
-            30 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_longblob',
-               'isClassString' => false,
-            )),
-            31 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_tinyint',
-               'isClassString' => false,
-            )),
-            32 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_int',
-               'isClassString' => false,
-            )),
-            33 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_smallint',
-               'isClassString' => false,
-            )),
-            34 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_mediumint',
-               'isClassString' => false,
-            )),
-            35 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_unsigned_bigint',
-               'isClassString' => false,
-            )),
-            36 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_json',
-               'isClassString' => false,
-            )),
-            37 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_json_not_null',
-               'isClassString' => false,
-            )),
-            38 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_decimal',
-               'isClassString' => false,
-            )),
-            39 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'c_decimal_not_null',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            1 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            2 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            3 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            6 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            7 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            8 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            9 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            10 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerRangeType::__set_state(array(
-                   'min' => 0,
-                   'max' => 2155,
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            11 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            12 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            13 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            14 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            15 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            16 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            17 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntegerType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            18 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -2147483648,
-               'max' => 2147483647,
-            )),
-            19 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            20 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            21 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -8388608,
-               'max' => 8388607,
-            )),
-            22 => 
-            PHPStan\Type\IntegerType::__set_state(array(
-            )),
-            23 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            24 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            25 => 
-            PHPStan\Type\FloatType::__set_state(array(
-            )),
-            26 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            27 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            28 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            29 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            30 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            31 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 255,
-            )),
-            32 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 4294967295,
-            )),
-            33 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 65535,
-            )),
-            34 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => 16777215,
-            )),
-            35 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => 0,
-               'max' => NULL,
-            )),
-            36 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            37 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            38 => 
-            PHPStan\Type\UnionType::__set_state(array(
-               'sortedTypes' => false,
-               'cachedDescriptions' => 
-              array (
-              ),
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\IntersectionType::__set_state(array(
-                   'sortedTypes' => true,
-                   'types' => 
-                  array (
-                    0 => 
-                    PHPStan\Type\StringType::__set_state(array(
-                    )),
-                    1 => 
-                    PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                    )),
-                  ),
-                )),
-                1 => 
-                PHPStan\Type\NullType::__set_state(array(
-                )),
-              ),
-               'normalized' => true,
-            )),
-            39 => 
-            PHPStan\Type\IntersectionType::__set_state(array(
-               'sortedTypes' => true,
-               'types' => 
-              array (
-                0 => 
-                PHPStan\Type\StringType::__set_state(array(
-                )),
-                1 => 
-                PHPStan\Type\Accessory\AccessoryNumericStringType::__set_state(array(
-                )),
-              ),
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT * FROM unknown_table' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.unknown_table\' doesn\'t exist',
          'code' => '42S02',
-      )),
-    ),
-    'SELECT *,adaid FROM `ada` WHERE email = \'test@example.com\';' => 
-    array (
-      'result' => 
-      array (
-        5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|4|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 4,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              8 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
-           'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
-                 'min' => -32768,
-                 'max' => 32767,
-              )),
-              1 => 
-              PHPStan\Type\StringType::__set_state(array(
-              )),
-            ),
-             'normalized' => true,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 5,
-          ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 0,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 1,
-            )),
-            4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 2,
-            )),
-            6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-            7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 3,
-            )),
-            8 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-               'value' => 4,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            4 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            5 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            8 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
-        )),
-      ),
-    ),
-    'SELECT FROM WHERE' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM WHERE LIMIT 0\' at line 1
-
-Simulated query: SELECT FROM WHERE LIMIT 0',
-         'code' => '42000',
       )),
     ),
     'SELECT adaid FROM ada WHERE email=\'1970-01-01\'' => 
@@ -2856,63 +1426,58 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\IntegerRangeType::__set_state(array(
+             'min' => -32768,
+             'max' => 32767,
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '0|\'adaid\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\IntegerRangeType::__set_state(array(
-             'min' => -32768,
-             'max' => 32767,
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 1,
-          ),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -2920,14 +1485,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 1,
+          ),
         )),
       ),
     ),
     'SELECT doesNotExist, adaid, gesperrt, freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'doesNotExist\' in \'field list\'',
          'code' => '42S22',
       )),
@@ -2937,103 +1510,109 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
              'sortedTypes' => true,
              'cachedDescriptions' => 
             array (
               2 => '0|\'email\'',
             ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
-          )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 1,
-          ),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
           ),
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 1,
+          ),
         )),
       ),
     ),
@@ -3042,42 +1621,45 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -3086,42 +1668,45 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\StringType::__set_state(array(
+          )),
            'keyType' => 
-          PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-             'objectType' => NULL,
-             'arrayKeyType' => NULL,
+          \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
              'value' => 'email',
              'isClassString' => false,
+             'objectType' => NULL,
+             'arrayKeyType' => NULL,
           )),
-           'itemType' => 
-          PHPStan\Type\StringType::__set_state(array(
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
@@ -3131,7 +1716,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
             LIMIT        1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 3',
          'code' => '42000',
       )),
@@ -3139,7 +1724,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid WHERE gesperrt FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 1',
          'code' => '42000',
       )),
@@ -3147,7 +1732,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'freigabe1u1 FROM ada LIMIT 0\' at line 1',
          'code' => '42000',
       )),
@@ -3155,7 +1740,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email adaid gesperrt freigabe1u1 FROM ada' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'gesperrt freigabe1u1 FROM ada LIMIT 0\' at line 1',
          'code' => '42000',
       )),
@@ -3165,105 +1750,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3271,7 +1851,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3280,129 +1868,124 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3410,7 +1993,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3419,105 +2010,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3525,7 +2111,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3534,105 +2128,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3640,14 +2229,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid FROM ada GROUP BY xy LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'xy\' in \'group statement\'',
          'code' => '42S22',
       )),
@@ -3657,105 +2254,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3763,7 +2355,369 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' OR adaid = \'10\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' OR adaid = \'10\' and email = \'hello world\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
+        )),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'1\' and email = \'hello world\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
+           'itemType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\StringType::__set_state(array(
+              )),
+              1 => 
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
+                 'min' => -32768,
+                 'max' => 32767,
+              )),
+            ),
+             'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 0,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+               'value' => 1,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
@@ -3772,129 +2726,124 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -3902,14 +2851,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid GROUP BY xy FROM ada  LIMIT 1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'FROM ada LIMIT 0\' at line 1',
          'code' => '42000',
       )),
@@ -3919,340 +2876,338 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            2 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'gesperrt',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            3 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'freigabe1u1',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+            2 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -128,
+               'max' => 127,
+            )),
+            3 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-            2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'gesperrt',
-               'isClassString' => false,
-            )),
-            3 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'freigabe1u1',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-            2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -128,
-               'max' => 127,
-            )),
-            3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4260,7 +3215,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4269,217 +3232,212 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4487,7 +3445,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4496,217 +3462,212 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'adaid',
-                   'isClassString' => false,
-                )),
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'email',
-                   'isClassString' => false,
-                )),
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'freigabe1u1',
-                   'isClassString' => false,
-                )),
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => 
-                PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                   'objectType' => NULL,
-                   'arrayKeyType' => NULL,
-                   'value' => 'gesperrt',
-                   'isClassString' => false,
-                )),
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'adaid',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'email',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'freigabe1u1',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => 
+                \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                   'value' => 'gesperrt',
+                   'isClassString' => false,
+                   'objectType' => NULL,
+                   'arrayKeyType' => NULL,
+                )),
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4714,7 +3675,15 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
@@ -4723,169 +3692,164 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -4893,14 +3857,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=\'1\'' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'asdsa\' in \'where clause\'',
          'code' => '42S22',
       )),
@@ -4908,7 +3880,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email, adaid, gesperrt, freigabe1u1 FROM ada WHERE asdsa=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'asdsa\' in \'where clause\'',
          'code' => '42S22',
       )),
@@ -4918,169 +3890,164 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 2,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 3,
-              )),
-              4 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              5 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-              6 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'freigabe1u1',
-                 'isClassString' => false,
-              )),
-              7 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'gesperrt',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 4,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 2,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 3,
+              )),
+              4 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              5 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              6 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'freigabe1u1',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              7 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'gesperrt',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|2|3|\'adaid\'|\'email\'|\'freigabe1u1\'|\'gesperrt\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
             4 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'gesperrt',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             5 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 2,
             )),
             6 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'freigabe1u1',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             7 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 3,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             4 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             5 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -128,
                'max' => 127,
             )),
             6 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             7 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -5088,14 +4055,22 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 4,
+          ),
         )),
       ),
     ),
     'SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND 1=1' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'does_not_exist\' in \'field list\'',
          'code' => '42S22',
       )),
@@ -5103,7 +4078,7 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
     'SELECT email, does_not_exist FROM ada WHERE email = \'1970-01-01\' AND email=\'test@example.com\'' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42S22]: Column not found: 1054 Unknown column \'does_not_exist\' in \'field list\'',
          'code' => '42S22',
       )),
@@ -5113,105 +4088,100 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
       'result' => 
       array (
         5 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '0|1|\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 0,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
-                 'value' => 1,
-              )),
-              2 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              3 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
           )),
-           'allArrays' => NULL,
-           'nextAutoIndexes' => 
-          array (
-            0 => 2,
-          ),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 0,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+                 'value' => 1,
+              )),
+              2 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              3 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '0|1|\'adaid\'|\'email\'',
+            ),
+          )),
            'keyTypes' => 
           array (
             0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'email',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             1 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 0,
             )),
             2 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
                'value' => 'adaid',
                'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
             )),
             3 => 
-            PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
+            \PHPStan\Type\Constant\ConstantIntegerType::__set_state(array(
                'value' => 1,
             )),
           ),
            'valueTypes' => 
           array (
             0 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             1 => 
-            PHPStan\Type\StringType::__set_state(array(
+            \PHPStan\Type\StringType::__set_state(array(
             )),
             2 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
             3 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
                'min' => -32768,
                'max' => 32767,
             )),
@@ -5219,117 +4189,112 @@ Simulated query: SELECT FROM WHERE LIMIT 0',
            'optionalKeys' => 
           array (
           ),
-           'isList' => false,
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
+          )),
+           'allArrays' => NULL,
+           'nextAutoIndexes' => 
+          array (
+            0 => 2,
+          ),
         )),
         3 => 
-        PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
-           'keyType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => true,
-             'cachedDescriptions' => 
-            array (
-              2 => '\'adaid\'|\'email\'',
-            ),
-             'types' => 
-            array (
-              0 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'adaid',
-                 'isClassString' => false,
-              )),
-              1 => 
-              PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-                 'objectType' => NULL,
-                 'arrayKeyType' => NULL,
-                 'value' => 'email',
-                 'isClassString' => false,
-              )),
-            ),
-             'normalized' => false,
-          )),
+        \PHPStan\Type\Constant\ConstantArrayType::__set_state(array(
            'itemType' => 
-          PHPStan\Type\UnionType::__set_state(array(
-             'sortedTypes' => false,
-             'cachedDescriptions' => 
-            array (
-            ),
+          \PHPStan\Type\UnionType::__set_state(array(
              'types' => 
             array (
               0 => 
-              PHPStan\Type\StringType::__set_state(array(
+              \PHPStan\Type\StringType::__set_state(array(
               )),
               1 => 
-              PHPStan\Type\IntegerRangeType::__set_state(array(
+              \PHPStan\Type\IntegerRangeType::__set_state(array(
                  'min' => -32768,
                  'max' => 32767,
               )),
             ),
              'normalized' => true,
+             'sortedTypes' => false,
+             'cachedDescriptions' => 
+            array (
+            ),
+          )),
+           'keyType' => 
+          \PHPStan\Type\UnionType::__set_state(array(
+             'types' => 
+            array (
+              0 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'adaid',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+              1 => 
+              \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+                 'value' => 'email',
+                 'isClassString' => false,
+                 'objectType' => NULL,
+                 'arrayKeyType' => NULL,
+              )),
+            ),
+             'normalized' => false,
+             'sortedTypes' => true,
+             'cachedDescriptions' => 
+            array (
+              2 => '\'adaid\'|\'email\'',
+            ),
+          )),
+           'keyTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'email',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+            1 => 
+            \PHPStan\Type\Constant\ConstantStringType::__set_state(array(
+               'value' => 'adaid',
+               'isClassString' => false,
+               'objectType' => NULL,
+               'arrayKeyType' => NULL,
+            )),
+          ),
+           'valueTypes' => 
+          array (
+            0 => 
+            \PHPStan\Type\StringType::__set_state(array(
+            )),
+            1 => 
+            \PHPStan\Type\IntegerRangeType::__set_state(array(
+               'min' => -32768,
+               'max' => 32767,
+            )),
+          ),
+           'optionalKeys' => 
+          array (
+          ),
+           'isList' => 
+          \PHPStan\TrinaryLogic::__set_state(array(
+             'value' => -1,
           )),
            'allArrays' => NULL,
            'nextAutoIndexes' => 
           array (
             0 => 0,
           ),
-           'keyTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'email',
-               'isClassString' => false,
-            )),
-            1 => 
-            PHPStan\Type\Constant\ConstantStringType::__set_state(array(
-               'objectType' => NULL,
-               'arrayKeyType' => NULL,
-               'value' => 'adaid',
-               'isClassString' => false,
-            )),
-          ),
-           'valueTypes' => 
-          array (
-            0 => 
-            PHPStan\Type\StringType::__set_state(array(
-            )),
-            1 => 
-            PHPStan\Type\IntegerRangeType::__set_state(array(
-               'min' => -32768,
-               'max' => 32767,
-            )),
-          ),
-           'optionalKeys' => 
-          array (
-          ),
-           'isList' => false,
         )),
       ),
     ),
     'SELECT with syntax error GROUPY by x' => 
     array (
       'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
+      \staabm\PHPStanDba\Error::__set_state(array(
          'message' => 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL/MariaDB server version for the right syntax to use near \'with syntax error GROUPY by x LIMIT 0\' at line 1',
          'code' => '42000',
-      )),
-    ),
-    'UPDATE adasfd SET email = ""' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.adasfd\' doesn\'t exist',
-         'code' => '42S02',
-      )),
-    ),
-    'UPDATE package SET indexedAt=\'1970-01-01\' WHERE id IN (NULL) AND (indexedAt IS NULL OR indexedAt <= crawledAt)' => 
-    array (
-      'error' => 
-      staabm\PHPStanDba\Error::__set_state(array(
-         'message' => 'SQLSTATE[42S02]: Base table or view not found: 1146 Table \'phpstan_dba.package\' doesn\'t exist',
-         'code' => '42S02',
       )),
     ),
   ),

--- a/tests/rules/data/pdo-stmt-execute-error.php
+++ b/tests/rules/data/pdo-stmt-execute-error.php
@@ -131,8 +131,8 @@ class Foo
     public function supportNestedQuotes(PDO $pdo)
     {
         $stmt = $pdo->prepare(<<<SQL
-            SELECT payload ->> '$."dash-separated"' = :value FROM ada WHERE 'foo'
-            SQL
+SELECT payload ->> '$."dash-separated"' = :value FROM ada WHERE 'foo'
+SQL
         );
         $stmt->execute(['value' => 'bar']);
     }

--- a/tests/rules/data/pdo-stmt-execute-error.php
+++ b/tests/rules/data/pdo-stmt-execute-error.php
@@ -127,4 +127,13 @@ class Foo
         $stmt = $pdo->prepare('SELECT email, adaid /* why? ? */ FROM ada /* just ?? :because ?*/ WHERE email = :email -- ?');
         $stmt->execute(['email' => 'a']);
     }
+
+    public function supportNestedQuotes(PDO $pdo)
+    {
+        $stmt = $pdo->prepare(<<<SQL
+            SELECT payload ->> '$."dash-separated"' = :value FROM ada WHERE 'foo'
+            SQL
+        );
+        $stmt->execute(['value' => 'bar']);
+    }
 }


### PR DESCRIPTION
Hi 👋 🙂 

I encountered an edge case with the Regex currently used to parse placeholders.

```
payload ->> '$."value-1"' = :value1
OR
payload ->> '$."value-2"' = :value2
```

ℹ️  `"` are needed here to escape the `-` special character in the field's name

The problem with the current `(["\'])([^"\']*\1)` regex is that it tries to exclude `'` **AND** `"` in the middle of a _string_. If this is a simply quoted string we should exclude only simple quotes. 

I found a way to negate a backreference in [stackoverflow](https://stackoverflow.com/a/8057827).

~Unfortunately, I totally failed to run tests locally, so I didn't add corresponding test... but I would love to if you have some helping instructions~ 
~[Edit] it seems that locally I got the same errors encountered by the CI, so maybe the issue is not related to my local setup but to `master` branch...~
[Edit 2 ] tests added 🎉  

Thanks for you work 🙏 



