### PR TITLE
Fix Doctrine Tests

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -92,7 +92,7 @@ jobs:
         if: "${{matrix.php-version != '7.2' && matrix.php-version != '7.3'}}"
 
       - name: Install doctrine/dbal (optional dependency)
-        run: composer require doctrine/dbal --ignore-platform-req=php+
+        run: composer require doctrine/dbal:^3 --ignore-platform-req=php+
         if: "${{matrix.php-version != '7.2'}}"
 
       - name: Enable phpstan@dev
@@ -147,7 +147,7 @@ jobs:
         if: "${{matrix.php-version != '7.2' && matrix.php-version != '7.3'}}"
 
       - name: Install doctrine/dbal (optional dependency)
-        run: composer require doctrine/dbal --ignore-platform-req=php+
+        run: composer require doctrine/dbal:^3 --ignore-platform-req=php+
         if: "${{matrix.php-version != '7.2'}}"
 
       - run: composer phpstan

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -58,7 +58,7 @@ jobs:
               if: "${{matrix.php-version != '7.2' && matrix.php-version != '7.3'}}"
 
             - name: Install doctrine/dbal (optional dependency)
-              run: composer require doctrine/dbal --ignore-platform-req=php+
+              run: composer require doctrine/dbal:^3 --ignore-platform-req=php+
               if: "${{matrix.php-version != '7.2'}}"
 
             - name: Setup Problem Matchers for PHPUnit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
       if: "${{matrix.php-version != '7.2' && matrix.php-version != '7.3'}}"
 
     - name: Install doctrine/dbal (optional dependency)
-      run: composer require doctrine/dbal --ignore-platform-req=php+
+      run: composer require doctrine/dbal:^3 --ignore-platform-req=php+
       if: "${{matrix.php-version != '7.2'}}"
 
     - name: Setup Problem Matchers for PHPUnit
@@ -184,7 +184,7 @@ jobs:
       if: "${{matrix.php-version != '7.2' && matrix.php-version != '7.3'}}"
 
     - name: Install doctrine/dbal (optional dependency)
-      run: composer require doctrine/dbal --ignore-platform-req=php+
+      run: composer require doctrine/dbal:^3 --ignore-platform-req=php+
       if: "${{matrix.php-version != '7.2'}}"
 
     - name: Setup Problem Matchers for PHPUnit


### PR DESCRIPTION
currently we don't support 4.x - PRs welcome ;)

phpstan-dba should work for doctrine/dbal 4.x methods which are backwards compatible to 3.x though, therefore we don't declare a composer conflict with doctrine/dbal 4.x