### PR TITLE
Fix placeholders detection with multiline strings

### DIFF
--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -42,9 +42,9 @@ final class QueryReflection
     // see https://github.com/php/php-src/blob/01b3fc03c30c6cb85038250bb5640be3a09c6a32/ext/pdo/pdo_sql_parser.re#L48
     private const NAMED_PATTERN = ':[a-zA-Z0-9_]+';
 
-    private const REGEX_UNNAMED_PLACEHOLDER = '{(["\'])((?:(?!\1).)*\1)|(' . self::UNNAMED_PATTERN . ')}';
+    private const REGEX_UNNAMED_PLACEHOLDER = '{(["\'])((?:(?!\1)(?s:.))*\1)|(' . self::UNNAMED_PATTERN . ')}';
 
-    private const REGEX_NAMED_PLACEHOLDER = '{(["\'])((?:(?!\1).)*\1)|(' . self::NAMED_PATTERN . ')}';
+    private const REGEX_NAMED_PLACEHOLDER = '{(["\'])((?:(?!\1)(?s:.))*\1)|(' . self::NAMED_PATTERN . ')}';
 
     /**
      * @var QueryReflector|null

--- a/tests/rules/data/pdo-stmt-execute-error.php
+++ b/tests/rules/data/pdo-stmt-execute-error.php
@@ -136,4 +136,14 @@ SQL
         );
         $stmt->execute(['value' => 'bar']);
     }
+
+    public function bug657MultilineString(PDO $pdo)
+    {
+        $stmt = $pdo->prepare(<<<SQL
+UPDATE `ada` SET email = "multi
+line" WHERE `email`= ? AND `email` = "value";
+SQL
+        );
+        $stmt->execute(['value']);
+    }
 }


### PR DESCRIPTION
Fix #657 

In #651, I included the `.` to mach _any_ character. Actually, it matches _any_ character except _newline_ 😅 

Here are [several workarounds from stackoverflow](https://stackoverflow.com/questions/8055727/negating-a-backreference-in-regular-expressions/8057827#8057827)

I choose to replace `.` by `(?s:.)`, because it locally changes the regex flag to also match newline character, without adding too much noise....

Added a test 🎁 