### PR TITLE
Reduce use of PreviousConnectingVisitor:: ATTRIBUTE_PARENT to assist garbage collector

### DIFF
--- a/src/Ast/ExpressionFinder.php
+++ b/src/Ast/ExpressionFinder.php
@@ -151,10 +151,6 @@ final class ExpressionFinder
         }
 
         $parent = $node->getAttribute(PreviousConnectingVisitor::ATTRIBUTE_PARENT);
-        if ($parent instanceof FunctionLike) {
-            return null;
-        }
-
         if ($parent instanceof Node) {
             return $this->findFirstPreviousOfNode($parent, $filter);
         }

--- a/src/Ast/PreviousConnectingVisitor.php
+++ b/src/Ast/PreviousConnectingVisitor.php
@@ -35,7 +35,13 @@ final class PreviousConnectingVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ([] !== $this->stack) {
-            $node->setAttribute(self::ATTRIBUTE_PARENT, $this->stack[\count($this->stack) - 1]);
+            $parent = $this->stack[\count($this->stack) - 1];
+            if (
+                !$parent instanceof Node\FunctionLike
+                && !$parent instanceof Node\Stmt\ClassLike
+            ) {
+                $node->setAttribute(self::ATTRIBUTE_PARENT, $parent);
+            }
         }
 
         if (null !== $this->previous && $this->previous->getAttribute(self::ATTRIBUTE_PARENT) === $node->getAttribute(self::ATTRIBUTE_PARENT)) {


### PR DESCRIPTION
idea is to have less Ast\Nodes with a pointer to the parent node, so the garbage collector has a easier job identifying unused nodes and clear memory. for our use-case its enough to know parents within functions/method bodies.

refs https://github.com/staabm/phpstan-dba/issues/667

---

in the long run it would be best to get rid of PreviousConnectingVisitor but I am currently not deep enough into the details of this lib todo such refactoring right now