### PR TITLE
Reduce use of PreviousConnectingVisitor::ATTRIBUTE_PREVIOUS to assist garbage collector

### DIFF
--- a/src/Ast/PreviousConnectingVisitor.php
+++ b/src/Ast/PreviousConnectingVisitor.php
@@ -38,8 +38,10 @@ final class PreviousConnectingVisitor extends NodeVisitorAbstract
             $node->setAttribute(self::ATTRIBUTE_PARENT, $this->stack[\count($this->stack) - 1]);
         }
 
-        if (null !== $this->previous && $this->previous->getAttribute(self::ATTRIBUTE_PARENT) === $node->getAttribute(self::ATTRIBUTE_PARENT)) {
-            $node->setAttribute(self::ATTRIBUTE_PREVIOUS, $this->previous);
+        if (!$node instanceof Node\FunctionLike && !$node instanceof Node\Stmt\ClassLike) {
+            if (null !== $this->previous && $this->previous->getAttribute(self::ATTRIBUTE_PARENT) === $node->getAttribute(self::ATTRIBUTE_PARENT)) {
+                $node->setAttribute(self::ATTRIBUTE_PREVIOUS, $this->previous);
+            }
         }
 
         $this->stack[] = $node;


### PR DESCRIPTION
idea is to have less Ast\Nodes with a pointer to the previous node, so the garbage collector has a easier job identifying unused nodes and clear memory. for our use-case its enough to know parents within functions/method bodies.

refs https://github.com/staabm/phpstan-dba/issues/667

---

in the long run it would be best to get rid of PreviousConnectingVisitor but I am currently not deep enough into the details of this lib todo such refactoring right now