### PR TITLE
PHPStan bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,118 +1,24 @@
-# `phpstan-dba`: PHPStan based SQL static analysis and type inference for the database access layer
+phpstan bug repro
 
-`phpstan-dba` makes your phpstan static code analysis jobs aware of datatypes within your database.
-With this information at hand we are able to detect type inconsistencies between your domain model and database-schema.
-Additionally errors in code handling the results of sql queries can be detected.
+- checkout the repository
+- composer install
 
-This extension provides the following features, as long as you [stick to the rules](https://staabm.github.io/2022/07/23/phpstan-dba-inference-placeholder.html#the-golden-phpstan-dba-rules):
+`vendor/bin/phpstan analyze src/SqlAst/ParserInference.php --debug`
 
-* [result set type-inference](https://staabm.github.io/2022/06/19/phpstan-dba-type-inference.html)
-* [detect errors in sql queries](https://staabm.github.io/2022/08/05/phpstan-dba-syntax-error-detection.html)
-* [detect placeholder/bound value mismatches](https://staabm.github.io/2022/07/30/phpstan-dba-placeholder-validation.html)
-* [query plan analysis](https://staabm.github.io/2022/08/16/phpstan-dba-query-plan-analysis.html) to detect performance issues
-* builtin support for `doctrine/dbal`, `mysqli`, and `PDO`
-* API to configure the same features for your custom sql based database access layer
-* Opt-In analysis of write queries (since version 0.2.55+)
+leads to
 
-In case you are using Doctrine ORM, you might use `phpstan-dba` in tandem with [phpstan-doctrine](https://github.com/phpstan/phpstan-doctrine).
-
-> [!NOTE]
-> At the moment only MySQL/MariaDB and PGSQL databases are supported. Technically it's not a big problem to support other databases though.
-
-## Talks
-
-[phpstan-dba - check your sql queries like a boss](https://staabm.github.io/talks/phpstan-dba@phpugffm/)
-May 2023, at PHP Usergroup in Frankfurt Main (Germany).
-
-## DEMO
-
-see the ['Files Changed' tab of the DEMO-PR](https://github.com/staabm/phpstan-dba/pull/61/files#diff-98a3c43049f6a0c859c0303037d9773534396533d7890bad187d465d390d634e) for a quick glance.
-
-## 💌 Support phpstan-dba
-
-[Consider supporting the project](https://github.com/sponsors/staabm), so we can make this tool even better even faster for everyone.
-
-## Installation
-
-**First**, use composer to install:
-
-```shell
-composer require --dev staabm/phpstan-dba
+```
+➜  phpstan-dba git:(staabm-patch-3) ✗ vendor/bin/phpstan analyze src/SqlAst/ParserInference.php --debug
+Note: Using configuration file /Users/staabm/workspace/phpstan-dba/phpstan.neon.dist.
+/Users/staabm/workspace/phpstan-dba/src/SqlAst/ParserInference.php
+ ------ ---------------------------------------------
+  Line   ParserInference.php
+ ------ ---------------------------------------------
+  51     Cannot call method getCondition() on mixed.
+         🪪  method.nonObject
+  55     Cannot call method getLeft() on mixed.
+         🪪  method.nonObject
+ ------ ---------------------------------------------
 ```
 
-**Second**, create a `phpstan-dba-bootstrap.php` file, which allows to you to configure `phpstan-dba` (this optionally includes database connection details, to introspect the database; if you would rather not do this see [Record and Replay](https://github.com/staabm/phpstan-dba/blob/main/docs/record-and-replay.md):
-
-```php
-<?php // phpstan-dba-bootstrap.php
-
-use staabm\PHPStanDba\DbSchema\SchemaHasherMysql;
-use staabm\PHPStanDba\QueryReflection\RuntimeConfiguration;
-use staabm\PHPStanDba\QueryReflection\MysqliQueryReflector;
-use staabm\PHPStanDba\QueryReflection\QueryReflection;
-use staabm\PHPStanDba\QueryReflection\ReplayAndRecordingQueryReflector;
-use staabm\PHPStanDba\QueryReflection\ReplayQueryReflector;
-use staabm\PHPStanDba\QueryReflection\ReflectionCache;
-
-require_once __DIR__ . '/vendor/autoload.php';
-
-$cacheFile = __DIR__.'/.phpstan-dba.cache';
-
-$config = new RuntimeConfiguration();
-// $config->debugMode(true);
-// $config->stringifyTypes(true);
-// $config->analyzeQueryPlans(true);
-// $config->utilizeSqlAst(true);
-
-// TODO: Put your database credentials here
-$mysqli = new mysqli('hostname', 'username', 'password', 'database');
-
-QueryReflection::setupReflector(
-    new ReplayAndRecordingQueryReflector(
-        ReflectionCache::create(
-            $cacheFile
-        ),
-        // XXX alternatively you can use PdoMysqlQueryReflector instead
-        new MysqliQueryReflector($mysqli),
-        new SchemaHasherMysql($mysqli)
-
-    ),
-    $config
-);
-```
-
-> [!NOTE]
-> [Configuration for PGSQL](https://github.com/staabm/phpstan-dba/blob/main/docs/pgsql.md) is pretty similar
-
-**Third**, create or update your `phpstan.neon` file so [bootstrapFiles](https://phpstan.org/config-reference#bootstrap) includes `phpstan-dba-bootstrap.php`.
-
-If you are **not** using [phpstan/extension-installer](https://github.com/phpstan/extension-installer), you will also need to include `dba.neon`.
-
-Your `phpstan.neon` might look something like:
-
-```neon
-parameters:
-  level: 8
-  paths:
-    - src/
-  bootstrapFiles:
-    - phpstan-dba-bootstrap.php
-
-includes:
-  - ./vendor/staabm/phpstan-dba/config/dba.neon
-```
-
-**Finally**, run `phpstan`, e.g.
-
-```shell
-./vendor/bin/phpstan analyse -c phpstan.neon
-```
-
-## Read more
-
-- [Runtime configuration](https://github.com/staabm/phpstan-dba/blob/main/docs/configuration.md)
-- [Record and Replay](https://github.com/staabm/phpstan-dba/blob/main/docs/record-and-replay.md)
-- [Custom Query API Support](https://github.com/staabm/phpstan-dba/blob/main/docs/rules.md)
-- [MySQL Support](https://github.com/staabm/phpstan-dba/blob/main/docs/mysql.md)
-- [PGSQL Support](https://github.com/staabm/phpstan-dba/blob/main/docs/pgsql.md)
-- [Reflector Overview](https://github.com/staabm/phpstan-dba/blob/main/docs/reflectors.md)
-- [How to analyze a PHP 7.x codebase?](https://github.com/staabm/phpstan-dba/blob/main/docs/faq.md)
+-> why does `$from` in `src/SqlAst/ParserInference.php` turn into `mixed`?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 phpstan bug repro
 
-- checkout the repository
+- clone the repository
+- checkout this PR
 - composer install
 
 `vendor/bin/phpstan analyze src/SqlAst/ParserInference.php --debug`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^8.5|^9.5",
 		"symplify/easy-coding-standard": "^12.3",
-		"tomasvotruba/unused-public": "^1.0",
 		"vlucas/phpdotenv": "^5.4"
 	},
 	"conflict": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"composer-runtime-api": "^2.0",
 		"composer/semver": "^3.2",
 		"doctrine/dbal": "3.*",
-		"phpstan/phpstan": "^1.9.4"
+		"phpstan/phpstan": "^2.0"
 	},
 	"require-dev": {
 		"ext-mysqli": "*",
@@ -16,9 +16,9 @@
 		"dibi/dibi": "^4.2",
 		"php-parallel-lint/php-parallel-lint": "^1.4",
 		"phpstan/extension-installer": "^1.4",
-		"phpstan/phpstan-deprecation-rules": "^1.1",
-		"phpstan/phpstan-phpunit": "^1.0",
-		"phpstan/phpstan-strict-rules": "^1.1",
+		"phpstan/phpstan-deprecation-rules": "^2.0",
+		"phpstan/phpstan-phpunit": "^2.0",
+		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^8.5|^9.5",
 		"symplify/easy-coding-standard": "^12.3",
 		"tomasvotruba/unused-public": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"composer-runtime-api": "^2.0",
 		"composer/semver": "^3.2",
 		"doctrine/dbal": "3.*",
-		"phpstan/phpstan": "^2.0"
+		"phpstan/phpstan": "^2.0",
+		"sqlftw/sqlftw": "^0.1.16"
 	},
 	"require-dev": {
 		"ext-mysqli": "*",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,33 +1,8 @@
 includes:
-    - config/extensions.neon
-    - config/rules.neon
     - phpstan-baseline.neon
 
 parameters:
-    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-
     level: max
 
     paths:
         - src/
-
-    bootstrapFiles:
-        - bootstrap.php
-
-    reportUnmatchedIgnoredErrors: false
-
-    ignoreErrors:
-        -
-            message: '#.*so it can be removed from the return type#'
-        -
-            message: '#^Method staabm\\PHPStanDba\\DbSchema\\SchemaHasherMysql\:\:hashDb\(\) should return string but returns float\|int\|string\.$#'
-            path: src/DbSchema/SchemaHasherMysql.php
-        -
-            message: '#^Property staabm\\PHPStanDba\\DbSchema\\SchemaHasherMysql\:\:\$hash \(string\|null\) does not accept float\|int\|string\.$#'
-            path: src/DbSchema/SchemaHasherMysql.php
-        -
-            message: '#^Instanceof between mysqli_result\<array\<string, int\|string\|null\>\> and mysqli_result will always evaluate to true\.$#'
-            path: src/DbSchema/SchemaHasherMysql.php
-        -
-            message: '#^Instanceof between mysqli_result<array<string, int<-2147483648, 2147483647>\|string\|null>> and mysqli_result will always evaluate to true\.$#'
-            path: src/DbSchema/SchemaHasherMysql.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,11 +14,6 @@ parameters:
     bootstrapFiles:
         - bootstrap.php
 
-    unused_public:
-        methods: true
-        properties: true
-        constants: true
-
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,6 +18,8 @@ parameters:
 
     ignoreErrors:
         -
+            message: '#.*so it can be removed from the return type#'
+        -
             message: '#^Method staabm\\PHPStanDba\\DbSchema\\SchemaHasherMysql\:\:hashDb\(\) should return string but returns float\|int\|string\.$#'
             path: src/DbSchema/SchemaHasherMysql.php
         -

--- a/src/DoctrineReflection/DoctrineResultObjectType.php
+++ b/src/DoctrineReflection/DoctrineResultObjectType.php
@@ -7,6 +7,7 @@ namespace staabm\PHPStanDba\DoctrineReflection;
 use Doctrine\DBAL\Result;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -51,10 +52,10 @@ final class DoctrineResultObjectType extends ObjectType
         return parent::equals($type);
     }
 
-    public function isSuperTypeOf(Type $type): TrinaryLogic
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
     {
         if ($type instanceof self) {
-            return TrinaryLogic::createFromBoolean(
+            return IsSuperTypeOfResult::createFromBoolean(
                 $type->rowType !== null
                 && $this->rowType !== null
                 && $type->rowType->equals($this->rowType)

--- a/src/DoctrineReflection/DoctrineStatementObjectType.php
+++ b/src/DoctrineReflection/DoctrineStatementObjectType.php
@@ -7,6 +7,7 @@ namespace staabm\PHPStanDba\DoctrineReflection;
 use Doctrine\DBAL\Statement;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -51,10 +52,10 @@ final class DoctrineStatementObjectType extends ObjectType
         return parent::equals($type);
     }
 
-    public function isSuperTypeOf(Type $type): TrinaryLogic
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
     {
         if ($type instanceof self) {
-            return TrinaryLogic::createFromBoolean(
+            return IsSuperTypeOfResult::createFromBoolean(
                 $type->rowType !== null
                 && $this->rowType !== null
                 && $type->rowType->equals($this->rowType)

--- a/src/Extensions/DibiConnectionFetchDynamicReturnTypeExtension.php
+++ b/src/Extensions/DibiConnectionFetchDynamicReturnTypeExtension.php
@@ -114,7 +114,7 @@ final class DibiConnectionFetchDynamicReturnTypeExtension implements DynamicMeth
         if ('fetch' === $methodName) {
             return TypeCombinator::addNull($resultType);
         } elseif ('fetchAll' === $methodName) {
-            return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), $resultType));
+            return TypeCombinator::intersect(new ArrayType(new IntegerType(), $resultType), new AccessoryArrayListType());
         } elseif ('fetchPairs' === $methodName && $resultType instanceof ConstantArrayType && 2 === \count($resultType->getValueTypes())) {
             return new ArrayType($resultType->getValueTypes()[0], $resultType->getValueTypes()[1]);
         } elseif ('fetchSingle' === $methodName && $resultType instanceof ConstantArrayType && 1 === \count($resultType->getValueTypes())) {

--- a/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
@@ -49,7 +49,7 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
         }
 
         if (null !== $inferredType) {
-            return $this->typeSpecifier->create($methodCall->var, $inferredType, TypeSpecifierContext::createTruthy(), true);
+            return $this->typeSpecifier->create($methodCall->var, $inferredType, TypeSpecifierContext::createTruthy(), $scope)->setAlwaysOverwriteTypes();
         }
 
         return new SpecifiedTypes();

--- a/src/Extensions/PdoStatementSetFetchModeTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementSetFetchModeTypeSpecifyingExtension.php
@@ -45,7 +45,7 @@ final class PdoStatementSetFetchModeTypeSpecifyingExtension implements MethodTyp
             $reducedType = $this->reduceType($methodCall, $statementType, $scope);
 
             if (null !== $reducedType) {
-                return $this->typeSpecifier->create($methodCall->var, $reducedType, TypeSpecifierContext::createTruthy(), true);
+                return $this->typeSpecifier->create($methodCall->var, $reducedType, TypeSpecifierContext::createTruthy(), $scope)->setAlwaysOverwriteTypes();
             }
         }
 

--- a/src/MysqliReflection/MysqliResultObjectType.php
+++ b/src/MysqliReflection/MysqliResultObjectType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace staabm\PHPStanDba\MysqliReflection;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -40,10 +41,10 @@ final class MysqliResultObjectType extends ObjectType
         return parent::equals($type);
     }
 
-    public function isSuperTypeOf(Type $type): TrinaryLogic
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
     {
         if ($type instanceof self) {
-            return TrinaryLogic::createFromBoolean(
+            return IsSuperTypeOfResult::createFromBoolean(
                 $type->rowType !== null
                 && $this->rowType !== null
                 && $type->rowType->equals($this->rowType)

--- a/src/PdoReflection/PdoStatementObjectType.php
+++ b/src/PdoReflection/PdoStatementObjectType.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
@@ -165,10 +166,10 @@ class PdoStatementObjectType extends ObjectType
         return parent::equals($type);
     }
 
-    public function isSuperTypeOf(Type $type): TrinaryLogic
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
     {
         if ($type instanceof self) {
-            return TrinaryLogic::createFromBoolean(
+            return IsSuperTypeOfResult::createFromBoolean(
                 $type->fetchType !== null
                 && $type->bothType !== null
                 && $this->bothType !== null

--- a/src/QueryReflection/BasePdoQueryReflector.php
+++ b/src/QueryReflection/BasePdoQueryReflector.php
@@ -53,7 +53,7 @@ abstract class BasePdoQueryReflector implements QueryReflector, RecordingReflect
     protected const MAX_CACHE_SIZE = 50;
 
     /**
-     * @var array<string, PDOException|list<ColumnMeta>|null>
+     * @var array<string, PDOException|array<ColumnMeta>|null>
      */
     protected array $cache = [];
 
@@ -69,7 +69,7 @@ abstract class BasePdoQueryReflector implements QueryReflector, RecordingReflect
     protected $stmt = null;
 
     /**
-     * @var array<string, array<string, list<string>>>
+     * @var array<string, array<string, array<string>>>
      */
     protected array $emulatedFlags = [];
 
@@ -138,7 +138,7 @@ abstract class BasePdoQueryReflector implements QueryReflector, RecordingReflect
     }
 
     /**
-     * @return list<string>
+     * @return array<string>
      */
     protected function emulateFlags(string $nativeType, string $tableName, string $columnName): array
     {
@@ -175,7 +175,7 @@ abstract class BasePdoQueryReflector implements QueryReflector, RecordingReflect
     }
 
     /**
-     * @return PDOException|list<ColumnMeta>|null
+     * @return PDOException|array<ColumnMeta>|null
      */
     abstract protected function simulateQuery(string $queryString);
 

--- a/src/QueryReflection/MysqliQueryReflector.php
+++ b/src/QueryReflection/MysqliQueryReflector.php
@@ -131,7 +131,7 @@ final class MysqliQueryReflector implements QueryReflector, RecordingReflector
     }
 
     /**
-     * @return mysqli_sql_exception|list<object>|null
+     * @return mysqli_sql_exception|array<object>|null
      */
     private function simulateQuery(string $queryString)
     {

--- a/src/QueryReflection/MysqliQueryReflector.php
+++ b/src/QueryReflection/MysqliQueryReflector.php
@@ -96,9 +96,13 @@ final class MysqliQueryReflector implements QueryReflector, RecordingReflector
         foreach ($result as $val) {
             if (
                 ! property_exists($val, 'name')
+                || ! is_string($val->name)
                 || ! property_exists($val, 'type')
+                || ! is_int($val->type)
                 || ! property_exists($val, 'flags')
+                || ! is_int($val->flags)
                 || ! property_exists($val, 'length')
+                || ! is_int($val->length)
             ) {
                 throw new ShouldNotHappenException();
             }

--- a/src/QueryReflection/PdoMysqlQueryReflector.php
+++ b/src/QueryReflection/PdoMysqlQueryReflector.php
@@ -31,7 +31,7 @@ class PdoMysqlQueryReflector extends BasePdoQueryReflector
     }
 
     /**
-     * @return PDOException|list<ColumnMeta>|null
+     * @return PDOException|array<ColumnMeta>|null
      */
     protected function simulateQuery(string $queryString)
     {

--- a/src/QueryReflection/PdoPgSqlQueryReflector.php
+++ b/src/QueryReflection/PdoPgSqlQueryReflector.php
@@ -13,7 +13,7 @@ use staabm\PHPStanDba\TypeMapping\TypeMapper;
 use function array_shift;
 
 /**
- * @phpstan-type PDOColumnMeta array{name: string, table?: string, native_type: string, len: int, flags: list<string>}
+ * @phpstan-type PDOColumnMeta array{name: string, table?: string, native_type: string, len: int, flags: array<string>}
  */
 final class PdoPgSqlQueryReflector extends BasePdoQueryReflector
 {
@@ -28,9 +28,9 @@ final class PdoPgSqlQueryReflector extends BasePdoQueryReflector
     }
 
     /**
-     * @return PDOException|list<PDOColumnMeta>|null
+     * @return PDOException|array<PDOColumnMeta>|null
      */
-    protected function simulateQuery(string $queryString) // @phpstan-ignore-line
+    protected function simulateQuery(string $queryString)
     {
         if (\array_key_exists($queryString, $this->cache)) {
             return $this->cache[$queryString];

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -206,7 +206,7 @@ final class QueryReflection
         }
         $isStringOrMixed = $type->isSuperTypeOf(new StringType());
 
-        return $isStringOrMixed->negate();
+        return $isStringOrMixed->negate()->result;
     }
 
     /**

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -7,6 +7,7 @@ namespace staabm\PHPStanDba\QueryReflection;
 use Composer\InstalledVersions;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\EncapsedStringPart;
 use PHPStan\Analyser\Scope;
@@ -372,6 +373,11 @@ final class QueryReflection
         if ($queryExpr instanceof Encapsed) {
             $string = '';
             foreach ($queryExpr->parts as $part) {
+                if ($part instanceof InterpolatedStringPart) {
+                    $string .= $part->value;
+                    continue;
+                }
+
                 $resolvedPart = $this->resolveQueryStringExpr($part, $scope);
                 if (null === $resolvedPart) {
                     return null;
@@ -380,10 +386,6 @@ final class QueryReflection
             }
 
             return $string;
-        }
-
-        if ($queryExpr instanceof EncapsedStringPart) {
-            return $queryExpr->value;
         }
 
         $type = $scope->getType($queryExpr);

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\EncapsedStringPart;
+use PhpParser\Node\Scalar\InterpolatedString;
 use PHPStan\Analyser\Scope;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
@@ -370,7 +371,7 @@ final class QueryReflection
             return $leftString . $rightString;
         }
 
-        if ($queryExpr instanceof Encapsed) {
+        if ($queryExpr instanceof InterpolatedString) {
             $string = '';
             foreach ($queryExpr->parts as $part) {
                 if ($part instanceof InterpolatedStringPart) {

--- a/src/SqlAst/ParserInference.php
+++ b/src/SqlAst/ParserInference.php
@@ -1,14 +1,9 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace staabm\PHPStanDba\SqlAst;
 
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use SqlFtw\Parser\Parser;
 use SqlFtw\Parser\ParserConfig;
@@ -16,29 +11,14 @@ use SqlFtw\Platform\Platform;
 use SqlFtw\Session\Session;
 use SqlFtw\Sql\Dml\Query\SelectCommand;
 use SqlFtw\Sql\Dml\Query\SelectExpression;
-use SqlFtw\Sql\Dml\TableReference\InnerJoin;
 use SqlFtw\Sql\Dml\TableReference\Join;
-use SqlFtw\Sql\Dml\TableReference\TableReferenceSubquery;
 use SqlFtw\Sql\Dml\TableReference\TableReferenceTable;
-use SqlFtw\Sql\Expression\Asterisk;
 use SqlFtw\Sql\Expression\Identifier;
-use SqlFtw\Sql\Expression\SimpleName;
 use SqlFtw\Sql\SqlSerializable;
-use staabm\PHPStanDba\QueryReflection\QueryReflection;
-use staabm\PHPStanDba\SchemaReflection\Join as SchemaJoin;
-use staabm\PHPStanDba\SchemaReflection\SchemaReflection;
 use staabm\PHPStanDba\SchemaReflection\Table;
-use staabm\PHPStanDba\UnresolvableAstInQueryException;
 
 final class ParserInference
 {
-    private SchemaReflection $schemaReflection;
-
-    public function __construct(SchemaReflection $schemaReflection)
-    {
-        $this->schemaReflection = $schemaReflection;
-    }
-
     public function narrowResultType(string $queryString, ConstantArrayType $resultType): Type
     {
         $platform = Platform::get(Platform::MYSQL, '8.0'); // version defaults to x.x.99 when no patch number is given
@@ -53,9 +33,6 @@ final class ParserInference
 
         $selectColumns = null;
         $fromTable = null;
-        $where = null;
-        $groupBy = null;
-        $joins = [];
         foreach ($commands as $command) {
             // Parser does not throw exceptions. this allows to parse partially invalid code and not fail on first error
             if ($command instanceof SelectCommand) {
@@ -63,64 +40,16 @@ final class ParserInference
                     $selectColumns = $command->getColumns();
                 }
                 $from = $command->getFrom();
-                $where = $command->getWhere();
-                $groupBy = $command->getGroupBy();
 
                 if (null === $from) {
                     // no FROM clause, use an empty Table to signify this
                     $fromTable = new Table('', []);
                 } elseif ($from instanceof TableReferenceTable) {
                     $fromName = $from->getTable()->getName();
-                    $fromTable = $this->schemaReflection->getTable($fromName);
                 } elseif ($from instanceof Join) {
                     while (1) {
                         if ($from->getCondition() === null) {
-                            if (QueryReflection::getRuntimeConfiguration()->isDebugEnabled()) {
-                                throw new UnresolvableAstInQueryException('Cannot narrow down types null join conditions: ' . $queryString);
-                            }
-
                             return $resultType;
-                        }
-
-                        if ($from->getRight() instanceof TableReferenceSubquery || $from->getLeft() instanceof TableReferenceSubquery) {
-                            if (QueryReflection::getRuntimeConfiguration()->isDebugEnabled()) {
-                                throw new UnresolvableAstInQueryException('Cannot narrow down types for SQLs with subqueries: ' . $queryString);
-                            }
-
-                            return $resultType;
-                        }
-
-                        if ($from instanceof InnerJoin && $from->isCrossJoin()) {
-                            if (QueryReflection::getRuntimeConfiguration()->isDebugEnabled()) {
-                                throw new UnresolvableAstInQueryException('Cannot narrow down types for cross joins: ' . $queryString);
-                            }
-
-                            return $resultType;
-                        }
-
-                        $joinType = SchemaJoin::TYPE_OUTER;
-
-                        if ($from instanceof InnerJoin) {
-                            $joinType = SchemaJoin::TYPE_INNER;
-                        }
-
-                        $joinedTable = $this->schemaReflection->getTable($from->getRight()->getTable()->getName());
-
-                        if ($joinedTable !== null) {
-                            $joins[] = new SchemaJoin(
-                                $joinType,
-                                $joinedTable,
-                                $from->getCondition()
-                            );
-                        }
-
-                        if ($from->getLeft() instanceof TableReferenceTable) {
-                            $from = $from->getLeft();
-
-                            $fromName = $from->getTable()->getName();
-                            $fromTable = $this->schemaReflection->getTable($fromName);
-
-                            break;
                         }
 
                         $from = $from->getLeft();
@@ -133,73 +62,7 @@ final class ParserInference
             // not parsable atm, return un-narrowed type
             return $resultType;
         }
-        if (null === $selectColumns) {
-            throw new ShouldNotHappenException();
-        }
-
-        $queryScope = new QueryScope($fromTable, $joins, $where, $groupBy !== null);
-
-        // If we're selecting '*', get the selected columns from the table
-        if (\count($selectColumns) === 1 && $selectColumns[0]->getExpression() instanceof Asterisk) {
-            $selectColumns = [];
-            foreach ($fromTable->getColumns() as $column) {
-                $selectColumns[] = new SelectExpression(new SimpleName($column->getName()));
-            }
-        }
-
-        foreach ($selectColumns as $i => $column) {
-            $expression = $column->getExpression();
-
-            $offsetType = new ConstantIntegerType($i);
-
-            $nameType = null;
-            $exprName = self::getIdentifierName($column);
-            if ($exprName !== null) {
-                $nameType = new ConstantStringType($exprName);
-            }
-            $rawExpressionType = null;
-            if ($column->getRawExpression() !== null) {
-                $rawExpressionType = new ConstantStringType($column->getRawExpression());
-            }
-            $aliasOffsetType = null;
-            if (null !== $column->getAlias()) {
-                $aliasOffsetType = new ConstantStringType($column->getAlias());
-            }
-
-            $valueType = $resultType->getOffsetValueType($offsetType);
-
-            $type = $queryScope->getType($expression);
-            if (! $type instanceof MixedType) {
-                $valueType = $type;
-            }
-
-            if (null !== $rawExpressionType && $resultType->hasOffsetValueType($rawExpressionType)->yes()) {
-                $resultType = $resultType->setOffsetValueType(
-                    $rawExpressionType,
-                    $valueType
-                );
-            }
-            if (null !== $aliasOffsetType && $resultType->hasOffsetValueType($aliasOffsetType)->yes()) {
-                $resultType = $resultType->setOffsetValueType(
-                    $aliasOffsetType,
-                    $valueType
-                );
-            }
-            if (null !== $nameType && $resultType->hasOffsetValueType($nameType)->yes()) {
-                $resultType = $resultType->setOffsetValueType(
-                    $nameType,
-                    $valueType
-                );
-            }
-            if ($resultType->hasOffsetValueType($offsetType)->yes()) {
-                $resultType = $resultType->setOffsetValueType(
-                    $offsetType,
-                    $valueType
-                );
-            }
-        }
-
-        return $resultType;
+        throw new ShouldNotHappenException();
     }
 
     /**

--- a/tests/default/data/dibi.php
+++ b/tests/default/data/dibi.php
@@ -19,7 +19,7 @@ class Foo
     public function fetchAll(\Dibi\Connection $connection)
     {
         $row = $connection->fetchAll('SELECT email, adaid FROM ada');
-        assertType('array<int, array{email: string, adaid: int<-32768, 32767>}>', $row);
+        assertType('list<array{email: string, adaid: int<-32768, 32767>}>', $row);
     }
 
     public function fetchPairs(\Dibi\Connection $connection)

--- a/tests/default/data/runMysqlQuery.php
+++ b/tests/default/data/runMysqlQuery.php
@@ -25,8 +25,8 @@ class Foo
     public function run(string $prodHostname, DbCredentials $dbCredentials)
     {
         $prodDomains = runMysqlQuery('SELECT cmsdomainid FROM cmsdomain WHERE url ="'.$prodHostname.'" and standard=1', $dbCredentials);
-        assertType('array<int, array<int, string>>|null', $prodDomains);
+        assertType('list<list<string>>|null', $prodDomains);
         // XXX should be more precise, when we would be smarter in query parsing
-        // assertType('array<int, array{string}>|null', $prodDomains);
+        // assertType('list<array{string}>|null', $prodDomains);
     }
 }

--- a/tests/rules/DoctrineKeyValueStyleRuleTest.php
+++ b/tests/rules/DoctrineKeyValueStyleRuleTest.php
@@ -27,6 +27,12 @@ class DoctrineKeyValueStyleRuleTest extends RuleTestCase
 
     public function testRule(): void
     {
+        $err56 = 'Query error: Column "ada.adaid" expects value type int, got type mixed';
+        if (PHP_VERSION_ID < 80000) {
+            // PHP 7.x does not support native mixed type
+            $err56 = 'Query error: Column "ada.adaid" expects value type int, got type DoctrineKeyValueStyleRuleTest\mixed';
+        }
+
         $expectedErrors = [
             [
                 'Argument #0 expects a constant string, got string',
@@ -65,7 +71,7 @@ class DoctrineKeyValueStyleRuleTest extends RuleTestCase
                 51,
             ],
             [
-                'Query error: Column "ada.adaid" expects value type int, got type mixed',
+                $err56,
                 56,
             ],
             [


### PR DESCRIPTION
phpstan bug repro

- clone the repository
- checkout this PR
- composer install

`vendor/bin/phpstan analyze src/SqlAst/ParserInference.php --debug`

leads to

```
➜  phpstan-dba git:(staabm-patch-3) ✗ vendor/bin/phpstan analyze src/SqlAst/ParserInference.php --debug
Note: Using configuration file /Users/staabm/workspace/phpstan-dba/phpstan.neon.dist.
/Users/staabm/workspace/phpstan-dba/src/SqlAst/ParserInference.php
 ------ ---------------------------------------------
  Line   ParserInference.php
 ------ ---------------------------------------------
  51     Cannot call method getCondition() on mixed.
         🪪  method.nonObject
  55     Cannot call method getLeft() on mixed.
         🪪  method.nonObject
 ------ ---------------------------------------------
```

-> why does `$from` in `src/SqlAst/ParserInference.php` turn into `mixed`?


--> don't look at the file-diff of this repro or commits of the PR, it doesn't matter
--> I already tried to extract the case at hand and reduce it even further, but this didn't work