### PR TITLE
Revert "Disable tomasvotruba/unused-public for now"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^8.5|^9.5",
 		"symplify/easy-coding-standard": "^12.4",
-		"tomasvotruba/unused-public": "^1.0",
+		"tomasvotruba/unused-public": "^2.0",
 		"vlucas/phpdotenv": "^5.4"
 	},
 	"conflict": {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^8.5|^9.5",
 		"symplify/easy-coding-standard": "^12.4",
+		"tomasvotruba/unused-public": "^1.0",
 		"vlucas/phpdotenv": "^5.4"
 	},
 	"conflict": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,6 +14,11 @@ parameters:
     bootstrapFiles:
         - bootstrap.php
 
+    unused_public:
+        methods: true
+        properties: true
+        constants: true
+
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:


### PR DESCRIPTION
This reverts commit f9cd010a7e8c46b11aab37e3f056dbd0fd908bf7.

re-enable after the tomasvotruba/unused-public extension works with PHPStan 2.x