### PR TITLE
Fix mixed row inference for PDOStatement::bindValue() + execute()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,6 +76,12 @@ parameters:
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantStringType is error\-prone and deprecated\. Use Type\:\:getConstantStrings\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 1
+			path: src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+
+		-
+			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantStringType is error\-prone and deprecated\. Use Type\:\:getConstantStrings\(\) instead\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 1
 			path: src/Rules/PdoStatementExecuteMethodRule.php
 
 		-

--- a/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
@@ -12,6 +12,9 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use PHPStan\Type\Type;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
@@ -62,9 +65,7 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
     {
         $args = $methodCall->getArgs();
 
-        if (0 === \count($args)) {
-            return null;
-        }
+       
 
         $stmtReflection = new PdoStatementReflection();
         $queryExpr = $stmtReflection->findPrepareQueryStringExpression($methodCall);
@@ -73,7 +74,28 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
         }
 
         $queryReflection = new QueryReflection();
-        $parameterTypes = $queryReflection->resolveParameterTypes($args[0]->value, $scope);
+        
+
+        if (0 === \count($args)) {
+            $parameterKeys = [];
+            $parameterValues = [];
+
+            foreach ($stmtReflection->findPrepareBindCalls($methodCall) as $bindCall) {
+                $bindArgs = $bindCall->getArgs();
+                if (\count($bindArgs) >= 2) {
+                    $keyType = $scope->getType($bindArgs[0]->value);
+                    if ($keyType instanceof ConstantIntegerType || $keyType instanceof ConstantStringType) {
+                        $parameterKeys[] = $keyType;
+                        $parameterValues[] = $scope->getType($bindArgs[1]->value);
+                    }
+                }
+            }
+
+            $parameterTypes = new ConstantArrayType($parameterKeys, $parameterValues);
+        } else {
+            $parameterTypes = $queryReflection->resolveParameterTypes($args[0]->value, $scope);
+        }
+
         $queryStrings = $queryReflection->resolvePreparedQueryStrings($queryExpr, $parameterTypes, $scope);
 
         $reflectionFetchType = QueryReflection::getRuntimeConfiguration()->getDefaultFetchMode();

--- a/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use PHPStan\Type\Type;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
@@ -84,8 +83,9 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
                 $bindArgs = $bindCall->getArgs();
                 if (\count($bindArgs) >= 2) {
                     $keyType = $scope->getType($bindArgs[0]->value);
-                    if ($keyType instanceof ConstantIntegerType || $keyType instanceof ConstantStringType) {
-                        $parameterKeys[] = $keyType;
+                    $constantStrings = $keyType->getConstantStrings();
+                    if ($keyType instanceof ConstantIntegerType || [] !== $constantStrings) {
+                        $parameterKeys[] = [] !== $constantStrings ? $constantStrings[0] : $keyType;
                         $parameterValues[] = $scope->getType($bindArgs[1]->value);
                     }
                 }

--- a/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
@@ -84,8 +84,11 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
                 if (\count($bindArgs) >= 2) {
                     $keyType = $scope->getType($bindArgs[0]->value);
                     $constantStrings = $keyType->getConstantStrings();
-                    if ($keyType instanceof ConstantIntegerType || [] !== $constantStrings) {
-                        $parameterKeys[] = [] !== $constantStrings ? $constantStrings[0] : $keyType;
+                    if ($keyType instanceof ConstantIntegerType) {
+                        $parameterKeys[] = $keyType;
+                        $parameterValues[] = $scope->getType($bindArgs[1]->value);
+                    } elseif ([] !== $constantStrings) {
+                        $parameterKeys[] = $constantStrings[0];
                         $parameterValues[] = $scope->getType($bindArgs[1]->value);
                     }
                 }

--- a/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
+++ b/src/Extensions/PdoStatementExecuteTypeSpecifyingExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use PHPStan\Type\Type;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
@@ -64,7 +65,7 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
     {
         $args = $methodCall->getArgs();
 
-       
+
 
         $stmtReflection = new PdoStatementReflection();
         $queryExpr = $stmtReflection->findPrepareQueryStringExpression($methodCall);
@@ -73,7 +74,6 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
         }
 
         $queryReflection = new QueryReflection();
-        
 
         if (0 === \count($args)) {
             $parameterKeys = [];
@@ -83,12 +83,8 @@ final class PdoStatementExecuteTypeSpecifyingExtension implements MethodTypeSpec
                 $bindArgs = $bindCall->getArgs();
                 if (\count($bindArgs) >= 2) {
                     $keyType = $scope->getType($bindArgs[0]->value);
-                    $constantStrings = $keyType->getConstantStrings();
-                    if ($keyType instanceof ConstantIntegerType) {
+                    if ($keyType instanceof ConstantIntegerType || $keyType instanceof ConstantStringType) {
                         $parameterKeys[] = $keyType;
-                        $parameterValues[] = $scope->getType($bindArgs[1]->value);
-                    } elseif ([] !== $constantStrings) {
-                        $parameterKeys[] = $constantStrings[0];
                         $parameterValues[] = $scope->getType($bindArgs[1]->value);
                     }
                 }

--- a/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
@@ -310,10 +310,6 @@ FROM ada' =>
         array (
           'type-description' => 'array{email: string, 0: string}',
         ),
-        3 => 
-        array (
-          'type-description' => 'array{email: string}',
-        ),
       ),
     ),
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
@@ -331,10 +327,6 @@ FROM ada' =>
         5 => 
         array (
           'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
-        ),
-        3 => 
-        array (
-          'type-description' => 'array{email: string, adaid: int<-32768, 32767>}',
         ),
       ),
     ),
@@ -369,6 +361,16 @@ FROM ada' =>
       ),
     ),
     'SELECT email, adaid FROM ada WHERE adaid = \'1\' and email = \'email@example.org\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'email@example.org\' and email = \'1\'' => 
     array (
       'result' => 
       array (
@@ -483,6 +485,16 @@ FROM ada' =>
       ),
     ),
     'SELECT email, adaid FROM ada WHERE email = \'webmaster@example.org\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE email = NULL AND email = \'1001\'' => 
     array (
       'result' => 
       array (

--- a/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
@@ -310,10 +310,6 @@ FROM ada' =>
         array (
           'type-description' => 'array{email: string, 0: string}',
         ),
-        3 => 
-        array (
-          'type-description' => 'array{email: string}',
-        ),
       ),
     ),
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
@@ -331,10 +327,6 @@ FROM ada' =>
         5 => 
         array (
           'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
-        ),
-        3 => 
-        array (
-          'type-description' => 'array{email: string, adaid: int<-32768, 32767>}',
         ),
       ),
     ),
@@ -369,6 +361,16 @@ FROM ada' =>
       ),
     ),
     'SELECT email, adaid FROM ada WHERE adaid = \'1\' and email = \'email@example.org\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE adaid = \'email@example.org\' and email = \'1\'' => 
     array (
       'result' => 
       array (
@@ -483,6 +485,16 @@ FROM ada' =>
       ),
     ),
     'SELECT email, adaid FROM ada WHERE email = \'webmaster@example.org\'' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'SELECT email, adaid FROM ada WHERE email = NULL AND email = \'1001\'' => 
     array (
       'result' => 
       array (

--- a/tests/default/data/pdo-stmt-execute.php
+++ b/tests/default/data/pdo-stmt-execute.php
@@ -9,6 +9,7 @@ class Foo
 {
     public function execute(PDO $pdo)
     {
+        
         $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
         $stmt->execute([':adaid' => 1]);
         foreach ($stmt as $row) {
@@ -33,11 +34,12 @@ class Foo
             assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
         }
 
-        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ? and email = ?');
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ? and email = ? ');
         $stmt->execute([1, 'email@example.org']);
         foreach ($stmt as $row) {
             assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
         }
+        
     }
 
     public function executeWithBindCalls(PDO $pdo)
@@ -48,6 +50,43 @@ class Foo
         $stmt->bindParam(':test1', $test);
         $stmt->bindValue(':test2', 1001);
         $stmt->execute();
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
+        $stmt->bindValue(':adaid', 1);
+        $stmt->execute();
+        foreach ($stmt as $row) {
+            assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
+        }
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
+        $stmt->bindValue('adaid', 1);
+        $stmt->execute(); // prefixed ":" is optional
+        foreach ($stmt as $row) {
+            assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
+        }
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE email = :email');
+        $stmt->bindValue(':email', 'email@example.org');
+        $stmt->execute();
+        foreach ($stmt as $row) {
+            assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
+        }
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ?');
+        $stmt->bindValue(1, 1);
+        $stmt->execute();
+        foreach ($stmt as $row) {
+            assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
+        }
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ? and email = ? ');
+        $stmt->bindValue(1, 1);
+        $stmt->bindValue(2, 'email@example.org');
+        $stmt->execute();
+        foreach ($stmt as $row) {
+            assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
+        }
+        
     }
 
     public function errors(PDO $pdo)

--- a/tests/default/data/pdo-stmt-execute.php
+++ b/tests/default/data/pdo-stmt-execute.php
@@ -34,7 +34,7 @@ class Foo
             assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);
         }
 
-        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ? and email = ? ');
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = ? and email = ?');
         $stmt->execute([1, 'email@example.org']);
         foreach ($stmt as $row) {
             assertType('array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}', $row);


### PR DESCRIPTION
## Summary

Fix row inference for PDO statements that use `bindValue()` before `execute()`.

The issue caused iterated rows to be inferred as `mixed` instead of the expected typed array shape.

## Changes

- add regression coverage for the `bindValue()` path
- update `PdoStatementExecuteTypeSpecifyingExtension` to preserve row typing after `execute()`

## Result

`foreach ($stmt as $row)` now keeps the expected inferred array type for supported `bindValue()` usages.