### PR TITLE
fix: support PDOStatement subclasses in PdoStatementExecuteMethodRule

### DIFF
--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -15,6 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ObjectType;
 use staabm\PHPStanDba\PdoReflection\PdoStatementReflection;
 use staabm\PHPStanDba\QueryReflection\PlaceholderValidation;
 use staabm\PHPStanDba\QueryReflection\QueryReflection;
@@ -38,12 +39,13 @@ final class PdoStatementExecuteMethodRule implements Rule
             return [];
         }
 
-        $methodReflection = $scope->getMethodReflection($scope->getType($methodCall->var), $methodCall->name->toString());
+        $varType = $scope->getType($methodCall->var);
+        $methodReflection = $scope->getMethodReflection($varType, $methodCall->name->toString());
         if (null === $methodReflection) {
             return [];
         }
 
-        if (! (new \PHPStan\Type\ObjectType(PDOStatement::class))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
+        if (! (new ObjectType(PDOStatement::class))->isSuperTypeOf($varType)->yes()) {
             return [];
         }
 

--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -43,7 +43,7 @@ final class PdoStatementExecuteMethodRule implements Rule
             return [];
         }
 
-        if (!(new \PHPStan\Type\ObjectType(PDOStatement::class))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
+        if (! (new \PHPStan\Type\ObjectType(PDOStatement::class))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
             return [];
         }
 

--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -45,11 +45,11 @@ final class PdoStatementExecuteMethodRule implements Rule
             return [];
         }
 
-        if (! (new ObjectType(PDOStatement::class))->isSuperTypeOf($varType)->yes()) {
+        if ('execute' !== strtolower($methodReflection->getName())) {
             return [];
         }
 
-        if ('execute' !== strtolower($methodReflection->getName())) {
+        if (! (new ObjectType(PDOStatement::class))->isSuperTypeOf($varType)->yes()) {
             return [];
         }
 

--- a/src/Rules/PdoStatementExecuteMethodRule.php
+++ b/src/Rules/PdoStatementExecuteMethodRule.php
@@ -43,7 +43,7 @@ final class PdoStatementExecuteMethodRule implements Rule
             return [];
         }
 
-        if (PDOStatement::class !== $methodReflection->getDeclaringClass()->getName()) {
+        if (!(new \PHPStan\Type\ObjectType(PDOStatement::class))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
             return [];
         }
 

--- a/tests/default/Fixture/MyPdoStatement.php
+++ b/tests/default/Fixture/MyPdoStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Tests\Fixture;
+
+class MyPdoStatement extends \PDOStatement
+{
+    public function execute(?array $params = null): bool
+    {
+        return parent::execute($params);
+    }
+}

--- a/tests/rules/PdoStatementExecuteMethodRuleTest.php
+++ b/tests/rules/PdoStatementExecuteMethodRuleTest.php
@@ -131,4 +131,22 @@ class PdoStatementExecuteMethodRuleTest extends RuleTestCase
             ],
         ]);
     }
+
+    public function testSubclassedPdoStatement(): void
+    {
+        $this->analyse([__DIR__ . '/data/pdo-stmt-execute-subclassed.php'], [
+            [
+                'Query expects placeholder :adaid, but it is missing from values given.',
+                14,
+            ],
+            [
+                'Value :wrongParamName is given, but the query does not contain this placeholder.',
+                14,
+            ],
+            [
+                'Query expects placeholder :adaid, but it is missing from values given.',
+                18,
+            ],
+        ]);
+    }
 }

--- a/tests/rules/data/pdo-stmt-execute-subclassed.php
+++ b/tests/rules/data/pdo-stmt-execute-subclassed.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PdoStatementExecuteSubclassedMethodRuleTest;
+
+use PDO;
+use staabm\PHPStanDba\Tests\Fixture\MyPdoStatement;
+
+class Foo
+{
+    public function errors(PDO $pdo): void
+    {
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
+        assert($stmt instanceof MyPdoStatement);
+        $stmt->execute(['wrongParamName' => 1]); // error: wrong param name
+
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
+        assert($stmt instanceof MyPdoStatement);
+        $stmt->execute(); // error: missing parameter
+    }
+
+    public function noErrors(PDO $pdo): void
+    {
+        $stmt = $pdo->prepare('SELECT email, adaid FROM ada WHERE adaid = :adaid');
+        assert($stmt instanceof MyPdoStatement);
+        $stmt->execute(['adaid' => 1]); // correct
+    }
+}


### PR DESCRIPTION
Hello, me again! Here is another problem I found while using your extension. Hope this helps.

## Problem


`PdoStatementExecuteMethodRule` was skipping analysis when `execute()` is called on a subclass of `PDOStatement` that overrides the method. This is because the rule checked whether `execute()` was *declared* in `PDOStatement`:
 
```php
if (PDOStatement::class !== $methodReflection->getDeclaringClass()->getName()) {
  return [];
}
```
  
When a subclass overrides execute(), the declaring class is the subclass and not PDOStatement, so the rule bailed out early, silently missing placeholder errors.
 
## Fix
 
Replace the declaring-class check with a type check on the call's receiver:

```php
if (!(new \PHPStan\Type\ObjectType(PDOStatement::class))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
  return []; 
}
```
 
This correctly handles PDOStatement itself and any subclass, regardless ofwhether execute() is inherited or overridden. 
 
## Tests
 
- Added MyPdoStatement fixture (extends PDOStatement, overrides execute())
- Added pdo-stmt-execute-subclassed.php test data with both error and no-error cases
- Added testSubclassedPdoStatement() to PdoStatementExecuteMethodRuleTest