### PR TITLE
DoctrineKeyValueStyleRule: support named parameters

### DIFF
--- a/src/Rules/DoctrineKeyValueStyleRule.php
+++ b/src/Rules/DoctrineKeyValueStyleRule.php
@@ -119,15 +119,22 @@ final class DoctrineKeyValueStyleRule implements Rule
             $methodReflection->getNamedArgumentsVariants(),
         );
 
-        $reorderedMethodCall = ArgumentsNormalizer::reorderMethodArguments(
-            $parametersAcceptor,
-            $callLike,
-        );
+        if ($callLike instanceof MethodCall) {
+            $reorderedCall = ArgumentsNormalizer::reorderMethodArguments(
+                $parametersAcceptor,
+                $callLike,
+            );
+        } else {
+            $reorderedCall = ArgumentsNormalizer::reorderNewArguments(
+                $parametersAcceptor,
+                $callLike,
+            );
+        }
 
-        if ($reorderedMethodCall === null) {
+        if ($reorderedCall === null) {
             return [];
         }
-        $reorderedArgs = $reorderedMethodCall->getArgs();
+        $reorderedArgs = $reorderedCall->getArgs();
 
         if (\count($reorderedArgs) < 1) {
             return [];

--- a/src/Rules/DoctrineKeyValueStyleRule.php
+++ b/src/Rules/DoctrineKeyValueStyleRule.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -109,36 +111,29 @@ final class DoctrineKeyValueStyleRule implements Rule
             return [];
         }
 
-        $args = $callLike->getArgs();
+        // Reorder arguments to account for named parameters
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $callLike->getArgs(),
+            $methodReflection->getVariants(),
+            $methodReflection->getNamedArgumentsVariants(),
+        );
 
-        if (\count($args) < 1) {
+        $reorderedMethodCall = ArgumentsNormalizer::reorderMethodArguments(
+            $parametersAcceptor,
+            $callLike,
+        );
+
+        if ($reorderedMethodCall === null) {
+            return [];
+        }
+        $reorderedArgs = $reorderedMethodCall->getArgs();
+
+        if (\count($reorderedArgs) < 1) {
             return [];
         }
 
-        // Map function parameter names to parameter index
-        $params = $methodReflection->getVariants()[0]->getParameters();
-        $paramNameToIndex = [];
-        foreach ($params as $i => $param) {
-            $paramNameToIndex[$param->getName()] = $i;
-        }
-
-        // Map parameter positions to actual call arguments
-        $paramIndexToArg = [];
-        foreach ($args as $i => $arg) {
-            if ($arg->name === null) {
-                // Positional argument
-                $paramIndexToArg[$i] = $arg;
-            } else {
-                // Named argument (PHP 8.0+)
-                $name = $arg->name->toString();
-                $index = $paramNameToIndex[$name] ?? null;
-                if ($index !== null) {
-                    $paramIndexToArg[$index] = $arg;
-                }
-            }
-        }
-
-        $tableExpr = $paramIndexToArg[0]->value;
+        $tableExpr = $reorderedArgs[0]->value;
         $tableType = $scope->getType($tableExpr);
         $tableNames = $tableType->getConstantStrings();
         if (\count($tableNames) === 0) {
@@ -166,11 +161,11 @@ final class DoctrineKeyValueStyleRule implements Rule
             foreach ($arrayArgPositions as $arrayArgPosition) {
                 // If the argument doesn't exist, just skip it since we don't want
                 // to error in case it has a default value
-                if (! \array_key_exists($arrayArgPosition, $paramIndexToArg)) {
+                if (! \array_key_exists($arrayArgPosition, $reorderedArgs)) {
                     continue;
                 }
 
-                $argType = $scope->getType($paramIndexToArg[$arrayArgPosition]->value);
+                $argType = $scope->getType($reorderedArgs[$arrayArgPosition]->value);
                 $argArrays = $argType->getConstantArrays();
                 if (\count($argArrays) === 0) {
                     $errors[] = 'Argument #' . $arrayArgPosition . ' is not a constant array, got ' . $argType->describe(VerbosityLevel::precise());

--- a/src/Rules/DoctrineKeyValueStyleRule.php
+++ b/src/Rules/DoctrineKeyValueStyleRule.php
@@ -115,7 +115,30 @@ final class DoctrineKeyValueStyleRule implements Rule
             return [];
         }
 
-        $tableExpr = $args[0]->value;
+        // Map function parameter names to parameter index
+        $params = $methodReflection->getVariants()[0]->getParameters();
+        $paramNameToIndex = [];
+        foreach ($params as $i => $param) {
+            $paramNameToIndex[$param->getName()] = $i;
+        }
+
+        // Map parameter positions to actual call arguments
+        $paramIndexToArg = [];
+        foreach ($args as $i => $arg) {
+            if ($arg->name === null) {
+                // Positional argument
+                $paramIndexToArg[$i] = $arg;
+            } else {
+                // Named argument (PHP 8.0+)
+                $name = $arg->name->toString();
+                $index = $paramNameToIndex[$name] ?? null;
+                if ($index !== null) {
+                    $paramIndexToArg[$index] = $arg;
+                }
+            }
+        }
+
+        $tableExpr = $paramIndexToArg[0]->value;
         $tableType = $scope->getType($tableExpr);
         $tableNames = $tableType->getConstantStrings();
         if (\count($tableNames) === 0) {
@@ -143,11 +166,11 @@ final class DoctrineKeyValueStyleRule implements Rule
             foreach ($arrayArgPositions as $arrayArgPosition) {
                 // If the argument doesn't exist, just skip it since we don't want
                 // to error in case it has a default value
-                if (! \array_key_exists($arrayArgPosition, $args)) {
+                if (! \array_key_exists($arrayArgPosition, $paramIndexToArg)) {
                     continue;
                 }
 
-                $argType = $scope->getType($args[$arrayArgPosition]->value);
+                $argType = $scope->getType($paramIndexToArg[$arrayArgPosition]->value);
                 $argArrays = $argType->getConstantArrays();
                 if (\count($argArrays) === 0) {
                     $errors[] = 'Argument #' . $arrayArgPosition . ' is not a constant array, got ' . $argType->describe(VerbosityLevel::precise());

--- a/tests/rules/DoctrineKeyValueStyleRuleTest.php
+++ b/tests/rules/DoctrineKeyValueStyleRuleTest.php
@@ -111,4 +111,18 @@ class DoctrineKeyValueStyleRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/doctrine-key-value-style-integer-ranges.php'], []);
     }
+
+    public function testNamedParameters(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            self::markTestSkipped('Test requires PHP 8.0');
+        }
+
+        $this->analyse([__DIR__ . '/data/doctrine-key-value-style-named-parameters.php'], [
+            [
+                'Query error: Column "ada.not_a_column" does not exist',
+                16,
+            ],
+        ]);
+    }
 }

--- a/tests/rules/data/doctrine-key-value-style-named-parameters.php
+++ b/tests/rules/data/doctrine-key-value-style-named-parameters.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace DoctrineKeyValueStyleRuleTest;
 

--- a/tests/rules/data/doctrine-key-value-style-named-parameters.php
+++ b/tests/rules/data/doctrine-key-value-style-named-parameters.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoctrineKeyValueStyleRuleTest;
+
+use staabm\PHPStanDba\Tests\Fixture\Connection;
+
+class Foo
+{
+    public function noErrorWithNamedParameters(Connection $conn)
+    {
+        $conn->assembleOneArray(cols: ['email' => 'foo'], tableName: 'ada');
+    }
+
+    public function errorWithNamedParameters(Connection $conn)
+    {
+        $conn->assembleOneArray(cols: ['not_a_column' => 'foo'], tableName: 'ada');
+    }
+}


### PR DESCRIPTION
Since we configure which arguments to check by their position, this can break if the arguments are specified at the call site with named parameters (PHP 8.0+), which allows arguments to be passed out of order.

By mapping named parameter arguments to the actual index in the function interface, we can properly handle out of order calls.