### PR TITLE
Fix mixed row inference for CTE (WITH ...) queries

### DIFF
--- a/.phpstan-dba-mysqli.cache
+++ b/.phpstan-dba-mysqli.cache
@@ -122,7 +122,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{COLUMN_NAME: string, 0: string, COLUMN_DEFAULT: string|null, 1: string|null, IS_NULLABLE: string, 2: string}',
+          'type-description' => 'array{COLUMN_NAME: string|null, 0: string|null, COLUMN_DEFAULT: string|null, 1: string|null, IS_NULLABLE: string, 2: string}',
         ),
       ),
     ),

--- a/.phpstan-dba-pdo-mysql.cache
+++ b/.phpstan-dba-pdo-mysql.cache
@@ -62,7 +62,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{COLUMN_NAME: string, 0: string, COLUMN_DEFAULT: string|null, 1: string|null, IS_NULLABLE: string, 2: string}',
+          'type-description' => 'array{COLUMN_NAME: string|null, 0: string|null, COLUMN_DEFAULT: string|null, 1: string|null, IS_NULLABLE: string, 2: string}',
         ),
       ),
     ),

--- a/src/QueryReflection/QueryReflection.php
+++ b/src/QueryReflection/QueryReflection.php
@@ -407,6 +407,12 @@ final class QueryReflection
             return strtoupper($matches[1]);
         }
 
+        // WITH [RECURSIVE] cte [(col_list)] AS (subquery) [, ...] <SELECT|INSERT|UPDATE|DELETE|REPLACE>
+        // (?1) recurses group 1 to balance parentheses inside subqueries.
+        if (1 === preg_match('/^\s*WITH\s+(?:RECURSIVE\s+)?[`"\w]+\s*(?:\([^)]*\))?\s*AS\s*(\((?:[^()]|(?1))*\))(?:\s*,\s*[`"\w]+\s*(?:\([^)]*\))?\s*AS\s*(?1))*\s*(SELECT|INSERT|UPDATE|DELETE|REPLACE)\b/i', $query, $matches)) {
+            return strtoupper($matches[2]);
+        }
+
         return null;
     }
 

--- a/tests/default/DbaInferenceTest.php
+++ b/tests/default/DbaInferenceTest.php
@@ -74,6 +74,7 @@ class DbaInferenceTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-union-result.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-default-fetch-types.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/bug372.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-cte.php');
     }
 
     /**

--- a/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
@@ -582,7 +582,7 @@ FROM ada' =>
         ),
       ),
     ),
-    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT n FROM cnt' => 
+    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT CAST(n AS SIGNED) AS n FROM cnt' => 
     array (
       'result' => 
       array (

--- a/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-mysqli.cache
@@ -310,6 +310,10 @@ FROM ada' =>
         array (
           'type-description' => 'array{email: string, 0: string}',
         ),
+        3 => 
+        array (
+          'type-description' => 'array{email: string}',
+        ),
       ),
     ),
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
@@ -327,6 +331,10 @@ FROM ada' =>
         5 => 
         array (
           'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+        3 => 
+        array (
+          'type-description' => 'array{email: string, adaid: int<-32768, 32767>}',
         ),
       ),
     ),
@@ -571,6 +579,66 @@ FROM ada' =>
         3 => 
         array (
           'type-description' => 'array{\'max(adaid)\': int<-32768, 32767>|null}',
+        ),
+      ),
+    ),
+    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT n FROM cnt' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{n: int|null, 0: int|null}',
+        ),
+      ),
+    ),
+    'WITH active_ada AS (SELECT email, adaid FROM ada WHERE gesperrt = 0) SELECT email, adaid FROM active_ada' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH counts AS (SELECT gesperrt, COUNT(*) AS total FROM ada GROUP BY gesperrt) SELECT gesperrt, total FROM counts' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{gesperrt: int<-128, 127>, 0: int<-128, 127>, total: int, 1: int}',
+        ),
+      ),
+    ),
+    'WITH cte AS (SELECT email, adaid FROM ada) SELECT * FROM cte' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH cte AS (SELECT email, adaid FROM ada) SELECT email, adaid FROM cte' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH emails AS (SELECT adaid, email FROM ada), unlocked AS (SELECT adaid FROM ada WHERE gesperrt = 0) SELECT e.email, e.adaid FROM emails e JOIN unlocked u ON u.adaid = e.adaid' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
         ),
       ),
     ),

--- a/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
@@ -582,7 +582,7 @@ FROM ada' =>
         ),
       ),
     ),
-    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT n FROM cnt' => 
+    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT CAST(n AS SIGNED) AS n FROM cnt' => 
     array (
       'result' => 
       array (

--- a/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
+++ b/tests/default/config/.phpunit-phpstan-dba-pdo-mysql.cache
@@ -310,6 +310,10 @@ FROM ada' =>
         array (
           'type-description' => 'array{email: string, 0: string}',
         ),
+        3 => 
+        array (
+          'type-description' => 'array{email: string}',
+        ),
       ),
     ),
     'SELECT email adaid WHERE gesperrt freigabe1u1 FROM ada' => 
@@ -327,6 +331,10 @@ FROM ada' =>
         5 => 
         array (
           'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+        3 => 
+        array (
+          'type-description' => 'array{email: string, adaid: int<-32768, 32767>}',
         ),
       ),
     ),
@@ -571,6 +579,66 @@ FROM ada' =>
         3 => 
         array (
           'type-description' => 'array{\'max(adaid)\': int<-32768, 32767>|null}',
+        ),
+      ),
+    ),
+    'WITH RECURSIVE cnt(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5) SELECT n FROM cnt' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{n: int|null, 0: int|null}',
+        ),
+      ),
+    ),
+    'WITH active_ada AS (SELECT email, adaid FROM ada WHERE gesperrt = 0) SELECT email, adaid FROM active_ada' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH counts AS (SELECT gesperrt, COUNT(*) AS total FROM ada GROUP BY gesperrt) SELECT gesperrt, total FROM counts' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{gesperrt: int<-128, 127>, 0: int<-128, 127>, total: int, 1: int}',
+        ),
+      ),
+    ),
+    'WITH cte AS (SELECT email, adaid FROM ada) SELECT * FROM cte' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH cte AS (SELECT email, adaid FROM ada) SELECT email, adaid FROM cte' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
+        ),
+      ),
+    ),
+    'WITH emails AS (SELECT adaid, email FROM ada), unlocked AS (SELECT adaid FROM ada WHERE gesperrt = 0) SELECT e.email, e.adaid FROM emails e JOIN unlocked u ON u.adaid = e.adaid' => 
+    array (
+      'result' => 
+      array (
+        5 => 
+        array (
+          'type-description' => 'array{email: string, 0: string, adaid: int<-32768, 32767>, 1: int<-32768, 32767>}',
         ),
       ),
     ),

--- a/tests/default/data/pdo-cte.php
+++ b/tests/default/data/pdo-cte.php
@@ -50,9 +50,12 @@ class Foo
 
     public function recursiveCte(PDO $pdo)
     {
+        // The outer CAST(n AS SIGNED) normalises the recursive integer column to
+        // BIGINT on both engines. Without it MariaDB reports a 32-bit INT (LONG)
+        // and MySQL a BIGINT (LONGLONG), which would infer different int ranges.
         $query = 'WITH RECURSIVE cnt(n) AS ('
             .'SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5'
-            .') SELECT n FROM cnt';
+            .') SELECT CAST(n AS SIGNED) AS n FROM cnt';
         $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
         foreach ($stmt as $row) {
             assertType('array{n: int|null}', $row);

--- a/tests/default/data/pdo-cte.php
+++ b/tests/default/data/pdo-cte.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PdoCteTest;
+
+use PDO;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+    public function simpleCte(PDO $pdo)
+    {
+        $query = 'WITH active_ada AS (SELECT email, adaid FROM ada WHERE gesperrt = 0) '
+            .'SELECT email, adaid FROM active_ada';
+        $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            assertType('array{email: string, adaid: int<-32768, 32767>}', $row);
+        }
+    }
+
+    public function cteSelectStar(PDO $pdo)
+    {
+        $query = 'WITH cte AS (SELECT email, adaid FROM ada) SELECT * FROM cte';
+        $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            assertType('array{email: string, adaid: int<-32768, 32767>}', $row);
+        }
+    }
+
+    public function multipleCtes(PDO $pdo)
+    {
+        $query = 'WITH '
+            .'emails AS (SELECT adaid, email FROM ada), '
+            .'unlocked AS (SELECT adaid FROM ada WHERE gesperrt = 0) '
+            .'SELECT e.email, e.adaid FROM emails e JOIN unlocked u ON u.adaid = e.adaid';
+        $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            assertType('array{email: string, adaid: int<-32768, 32767>}', $row);
+        }
+    }
+
+    public function cteWithAggregation(PDO $pdo)
+    {
+        $query = 'WITH counts AS (SELECT gesperrt, COUNT(*) AS total FROM ada GROUP BY gesperrt) '
+            .'SELECT gesperrt, total FROM counts';
+        $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            assertType('array{gesperrt: int<-128, 127>, total: int}', $row);
+        }
+    }
+
+    public function recursiveCte(PDO $pdo)
+    {
+        $query = 'WITH RECURSIVE cnt(n) AS ('
+            .'SELECT 1 UNION ALL SELECT n + 1 FROM cnt WHERE n < 5'
+            .') SELECT n FROM cnt';
+        $stmt = $pdo->query($query, PDO::FETCH_ASSOC);
+        foreach ($stmt as $row) {
+            assertType('array{n: int|null}', $row);
+        }
+    }
+
+    public function cteFetchNumeric(PDO $pdo)
+    {
+        $query = 'WITH cte AS (SELECT email, adaid FROM ada) SELECT email, adaid FROM cte';
+        $stmt = $pdo->query($query, PDO::FETCH_NUM);
+        foreach ($stmt as $row) {
+            assertType('array{string, int<-32768, 32767>}', $row);
+        }
+    }
+}

--- a/tests/sqlAst/config/.phpunit-phpstan-dba-mysqli.cache
+++ b/tests/sqlAst/config/.phpunit-phpstan-dba-mysqli.cache
@@ -164,7 +164,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{str: string, 0: string}',
+          'type-description' => 'array{str: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -204,7 +204,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{str: string, 0: string}',
+          'type-description' => 'array{str: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -744,7 +744,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -754,7 +754,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -794,7 +794,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -804,7 +804,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -954,7 +954,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: mixed, 0: mixed}',
         ),
       ),
     ),
@@ -1104,7 +1104,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1154,7 +1154,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1164,7 +1164,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1184,7 +1184,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1194,7 +1194,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1214,7 +1214,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1554,7 +1554,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1564,7 +1564,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),

--- a/tests/sqlAst/config/.phpunit-phpstan-dba-pdo-mysql.cache
+++ b/tests/sqlAst/config/.phpunit-phpstan-dba-pdo-mysql.cache
@@ -164,7 +164,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{str: string, 0: string}',
+          'type-description' => 'array{str: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -204,7 +204,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{str: string, 0: string}',
+          'type-description' => 'array{str: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -744,7 +744,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -754,7 +754,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -794,7 +794,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -804,7 +804,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -954,7 +954,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: mixed, 0: mixed}',
         ),
       ),
     ),
@@ -1104,7 +1104,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1154,7 +1154,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1164,7 +1164,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1184,7 +1184,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1194,7 +1194,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{col: string, 0: string}',
+          'type-description' => 'array{col: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1214,7 +1214,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1554,7 +1554,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),
@@ -1564,7 +1564,7 @@
       array (
         5 => 
         array (
-          'type-description' => 'array{field: string, 0: string}',
+          'type-description' => 'array{field: string|null, 0: string|null}',
         ),
       ),
     ),


### PR DESCRIPTION
Fix row inference for queries starting with `WITH [RECURSIVE]`.

The issue caused iterated rows to be inferred as mixed instead of the expected typed array shape, because `getQueryType()` did not recognise CTE queries as SELECT-equivalent and bailed out before reaching the reflector.

Changes:
- add regression coverage for the CTE path (simple, multi, recursive, aggregation, SELECT *, FETCH_NUM)
- update QueryReflection::getQueryType() to skip past CTE definitions and return the inner statement keyword

Result:
foreach ($stmt as $row) now keeps the expected inferred array type for `WITH cte AS (...) SELECT ... FROM cte` queries.