### PR TITLE
Preserve reflector-derived column types when AST narrowing yields ErrorType

### DIFF
--- a/src/SqlAst/ParserInference.php
+++ b/src/SqlAst/ParserInference.php
@@ -8,7 +8,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use SqlFtw\Parser\Parser;
@@ -173,19 +172,21 @@ final class ParserInference
                 $aliasOffsetType = new ConstantStringType($column->getAlias());
             }
 
-            $valueType = $resultType->getOffsetValueType($offsetType);
+            // FETCH_TYPE_ASSOC rows are string-keyed; guard the integer-offset
+            // read — since PHPStan 2.2 missing-offset reads return ErrorType.
+            $valueType = null;
+            if ($resultType->hasOffsetValueType($offsetType)->yes()) {
+                $valueType = $resultType->getOffsetValueType($offsetType);
+            }
 
             $type = $queryScope->getType($expression);
             if (! $type instanceof MixedType) {
                 $valueType = $type;
             }
 
-            // PHPStan 2.2+ returns ErrorType when reading a missing offset (here
-            // the integer offset is missing on a string-keyed assoc row shape).
-            // If QueryScope couldn't refine the column either (e.g. alias-qualified
-            // references like `t.col`, which resolveExpression() returns MixedType
-            // for), there is nothing to narrow — keep the reflector-derived type.
-            if ($valueType instanceof ErrorType) {
+            // Hit on alias-qualified columns over assoc rows: no integer seed,
+            // and resolveExpression() falls through to MixedType for `t.col`.
+            if ($valueType === null) {
                 continue;
             }
 

--- a/src/SqlAst/ParserInference.php
+++ b/src/SqlAst/ParserInference.php
@@ -8,6 +8,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use SqlFtw\Parser\Parser;
@@ -177,6 +178,15 @@ final class ParserInference
             $type = $queryScope->getType($expression);
             if (! $type instanceof MixedType) {
                 $valueType = $type;
+            }
+
+            // PHPStan 2.2+ returns ErrorType when reading a missing offset (here
+            // the integer offset is missing on a string-keyed assoc row shape).
+            // If QueryScope couldn't refine the column either (e.g. alias-qualified
+            // references like `t.col`, which resolveExpression() returns MixedType
+            // for), there is nothing to narrow — keep the reflector-derived type.
+            if ($valueType instanceof ErrorType) {
+                continue;
             }
 
             if (null !== $rawExpressionType && $resultType->hasOffsetValueType($rawExpressionType)->yes()) {

--- a/tests/default/ParserInferenceTest.php
+++ b/tests/default/ParserInferenceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace staabm\PHPStanDba\Tests;
+
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\TestCase;
+use staabm\PHPStanDba\SchemaReflection\SchemaReflection;
+use staabm\PHPStanDba\SqlAst\ParserInference;
+
+class ParserInferenceTest extends TestCase
+{
+    /**
+     * Regression: with FETCH_TYPE_ASSOC the reflector-derived row shape is
+     * string-keyed only. Reading an integer offset on it returns ErrorType
+     * under PHPStan >= 2.2 (previously a benign type). For alias-qualified
+     * columns (`t.col`) QueryScope::resolveExpression() returns MixedType,
+     * so the ErrorType used to be written over the (correct) reflector type
+     * under the column name key, collapsing the row shape to
+     * `array{col: *ERROR*, ...}`.
+     *
+     * @dataProvider provideAliasedAndUnaliasedQueries
+     */
+    public function testAssocOnlyRowShapeIsPreservedForAliasedColumns(string $sql): void
+    {
+        $serviceGroupIdType = IntegerRangeType::fromInterval(0, 4294967295);
+        $nameType = new StringType();
+
+        // mysqli FETCH_TYPE_ASSOC row shape: ONLY string keys, no integer offsets.
+        $resultType = new ConstantArrayType(
+            [
+                new ConstantStringType('service_group_id'),
+                new ConstantStringType('name'),
+            ],
+            [
+                $serviceGroupIdType,
+                $nameType,
+            ]
+        );
+
+        $schema = new SchemaReflection(static function (string $query) use ($resultType): ?Type {
+            if (stripos($query, 'SELECT * FROM service_group') === 0) {
+                return $resultType;
+            }
+            return null;
+        });
+
+        $inference = new ParserInference($schema);
+        $narrowed = $inference->narrowResultType($sql, $resultType);
+
+        self::assertSame(
+            'array{service_group_id: int<0, 4294967295>, name: string}',
+            $narrowed->describe(VerbosityLevel::precise())
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function provideAliasedAndUnaliasedQueries(): iterable
+    {
+        yield 'unqualified columns' => [
+            'SELECT service_group_id, name FROM service_group',
+        ];
+        yield 'alias-qualified columns' => [
+            'SELECT sg.service_group_id, sg.name FROM service_group sg',
+        ];
+    }
+}


### PR DESCRIPTION
# Preserve reflector-derived column types when AST narrowing yields `ErrorType`

## Issue

With `utilizeSqlAst(true)` + `defaultFetchMode(FETCH_TYPE_ASSOC)` on PHPStan **2.2+**, any `SELECT` that references columns through a table alias collapses every column's value type to `*ERROR*`:

```php
// service_group(service_group_id int unsigned, name varchar(45))

SELECT service_group_id, name FROM service_group
//  array{service_group_id: int<0, 4294967295>, name: string}        ✅

SELECT sg.service_group_id, sg.name FROM service_group sg
//  array{service_group_id: *ERROR*, name: *ERROR*}                  ❌
```

Worked on PHPStan 2.1; regressed in 2.2.

### Why

In `ParserInference::narrowResultType()`, per column:

1. `$valueType = $resultType->getOffsetValueType(ConstantIntegerType($i))` — but the `FETCH_TYPE_ASSOC` row shape from the reflector is string-keyed only. PHPStan 2.2 changed missing-offset reads to return `ErrorType` (previously benign).
2. `$queryScope->getType($expression)` is supposed to refine it. For unqualified columns it returns the real column type and overwrites the `ErrorType`. For alias-qualified columns (`t.col`) `resolveExpression()` has no branch for qualified identifiers and falls through to `MixedType`, so the guard `! $type instanceof MixedType` skips the assignment.
3. `$valueType` (still `ErrorType`) is then written over the correct reflector-derived type under the column-name key.

## Fix

After the QueryScope refinement step, skip the column when `$valueType` is still `ErrorType` — there is no information to add, so leave the reflector's type untouched.

```php
$type = $queryScope->getType($expression);
if (! $type instanceof MixedType) {
    $valueType = $type;
}

if ($valueType instanceof ErrorType) {
    continue;
}
```

Minimal, targeted: only changes behavior on the previously-broken path. A follow-up could teach `QueryScope::resolveExpression()` to resolve qualified identifiers and restore full AST narrowing (JOIN/WHERE nullability) for aliased columns, but that's a larger change.

## Test

Added `tests/default/ParserInferenceTest.php` — a plain PHPUnit test that drives `ParserInference::narrowResultType()` directly with a synthetic assoc-only `ConstantArrayType`, covering both unqualified and `t.col`-qualified queries. Fails without the patch (`*ERROR*` in the alias-qualified case), passes with it.